### PR TITLE
Add responsive Beaches & Coast page with source attribution

### DIFF
--- a/beaches-coast.html
+++ b/beaches-coast.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>AOTEAROA | Beaches & Coast</title>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+  <link rel="stylesheet" href="css/normalize.css">
+  <link rel="stylesheet" href="css/beaches-coast.css">
+</head>
+
+<body>
+  <header class="coast-hero">
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+      <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
+          alt="New Zealand fern logo"></a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="nav navbar-nav">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item active"><a class="nav-link" href="beaches-coast.html">Beaches & Coast <span
+                class="sr-only">(current)</span></a></li>
+          <li class="nav-item"><a class="nav-link" href="attractions.html">Attractions</a></li>
+          <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="hero-overlay">
+      <div class="container">
+        <h1>Beaches & Coast of Aotearoa</h1>
+        <p>Uncrowded shorelines, dramatic views, and easy coastal day trips across both islands.</p>
+      </div>
+    </div>
+  </header>
+
+  <main class="container py-5">
+    <section class="mb-5">
+      <h2>Why New Zealand's Coastline Stands Out</h2>
+      <p>
+        New Zealand's long coastline makes it easy to find a beach that feels peaceful and open. From bright sand bays
+        to rugged headlands, the coast offers places for swimming, surfing, picnics, and scenic walks.
+      </p>
+    </section>
+
+    <section class="mb-5">
+      <h2>Popular North Island Beaches</h2>
+      <div class="row">
+        <div class="col-md-6 col-lg-4 mb-3">
+          <article class="coast-card h-100">
+            <h3>Cathedral Cove</h3>
+            <p>Known for its natural rock arch, clear water, and photo-worthy coastal track.</p>
+          </article>
+        </div>
+        <div class="col-md-6 col-lg-4 mb-3">
+          <article class="coast-card h-100">
+            <h3>Ninety Mile Beach</h3>
+            <p>A vast stretch of shoreline in the far north, great for long walks and big-sky sunsets.</p>
+          </article>
+        </div>
+        <div class="col-md-6 col-lg-4 mb-3">
+          <article class="coast-card h-100">
+            <h3>Piha & Raglan</h3>
+            <p>Wild west-coast surf spots with black-sand beaches and dramatic volcanic landscapes.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="mb-5">
+      <h2>South Island Coastal Highlights</h2>
+      <div class="row">
+        <div class="col-md-6 mb-3">
+          <article class="coast-card h-100">
+            <h3>Tunnel Beach & St Clair</h3>
+            <p>Historic and windswept Dunedin coastlines with cliffs, waves, and walking access.</p>
+          </article>
+        </div>
+        <div class="col-md-6 mb-3">
+          <article class="coast-card h-100">
+            <h3>Moeraki & Golden Bay</h3>
+            <p>From unusual round boulders to calm northern bays, this coast blends geology and relaxation.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="travel-tips">
+      <h2>Coastal Trip Tips</h2>
+      <ul>
+        <li>Pack sun protection and layers; beach weather can change quickly.</li>
+        <li>Check local conditions before swimming or surfing.</li>
+        <li>Keep flexibility in your plan for spontaneous stops and viewpoints.</li>
+      </ul>
+    </section>
+
+    <section class="attribution mt-5">
+      <h2>Source & Attribution</h2>
+      <p>
+        This page paraphrases destination ideas from Tourism New Zealand's “Beaches & Coast in New Zealand” page.
+      </p>
+      <p>
+        Original source:
+        <a href="https://www.newzealand.com/nz/beaches-and-coast/" target="_blank" rel="noopener noreferrer">
+          https://www.newzealand.com/nz/beaches-and-coast/
+        </a>
+      </p>
+    </section>
+  </main>
+
+  <footer class="page-footer font-small bg-dark text-light text-center py-3">
+    © 2018 Copyright: <a class="text-light" href="https://www.facebook.com/luke.gilchrist.35">LUKE PONGA</a>
+  </footer>
+
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1"
+    crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
+    crossorigin="anonymous"></script>
+</body>
+
+</html>

--- a/beaches-coast.html
+++ b/beaches-coast.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
     integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <link rel="stylesheet" href="css/normalize.css">
+  <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/beaches-coast.css">
 </head>
 

--- a/beaches-coast.html
+++ b/beaches-coast.html
@@ -128,6 +128,7 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
     integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
     crossorigin="anonymous"></script>
+  <script src="scripts/main.js"></script>
 </body>
 
 </html>

--- a/beaches-coast.html
+++ b/beaches-coast.html
@@ -26,6 +26,7 @@
           <li class="nav-item active"><a class="nav-link" href="beaches-coast.html">Beaches & Coast <span
                 class="sr-only">(current)</span></a></li>
           <li class="nav-item"><a class="nav-link" href="attractions.html">Attractions</a></li>
+          <li class="nav-item"><a class="nav-link" href="history.html">History</a></li>
           <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
           <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
         </ul>

--- a/css/beaches-coast.css
+++ b/css/beaches-coast.css
@@ -1,0 +1,70 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  background: #f7fbfd;
+  color: #1a1a1a;
+}
+
+.coast-hero {
+  min-height: 52vh;
+  background: linear-gradient(rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0.35)), url("../images/coromandel.jpg") center/cover no-repeat;
+  display: flex;
+  align-items: flex-end;
+  margin-bottom: 1rem;
+}
+
+.hero-overlay {
+  width: 100%;
+  padding: 7rem 0 3rem;
+  color: #fff;
+}
+
+.hero-overlay h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+main h2 {
+  font-size: 1.7rem;
+  margin-bottom: 1rem;
+  color: #073b4c;
+}
+
+.coast-card {
+  background: #fff;
+  border: 1px solid #d8e6ec;
+  border-radius: 10px;
+  padding: 1rem;
+  box-shadow: 0 2px 10px rgba(7, 59, 76, 0.06);
+}
+
+.coast-card h3 {
+  font-size: 1.2rem;
+  margin-bottom: 0.45rem;
+  color: #005f73;
+}
+
+.travel-tips {
+  background: #e9f6fb;
+  border-left: 4px solid #0a9396;
+  border-radius: 8px;
+  padding: 1rem 1rem 0.75rem;
+}
+
+.travel-tips ul {
+  padding-left: 1.2rem;
+}
+
+.attribution {
+  font-size: 0.95rem;
+}
+
+@media (max-width: 767px) {
+  .hero-overlay {
+    padding-top: 6rem;
+  }
+
+  main {
+    padding-top: 1rem !important;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
                 class="sr-only">(current)</span></a></li>
           <li class="nav-item"><a class="nav-link" href="attractions.html">Main Attractions & Locations</a></li>
           <li class="nav-item"><a class="nav-link" href="history.html">New Zealands History</a></li>
+          <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
           <li class="nav-item"><a class="nav-link" href="events.html">Coming Events</a></li>
           <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
         </ul>


### PR DESCRIPTION
### Motivation
- Provide a dedicated, mobile-friendly page that summarizes Beaches & Coast information for the site using paraphrased content from the Tourism New Zealand resource.
- Keep the site navigation discoverable by adding a link to the new page from the main menu.

### Description
- Added a new page `beaches-coast.html` that paraphrases content from `https://www.newzealand.com/nz/beaches-and-coast/` and includes sections for North Island and South Island highlights, travel tips, and explicit attribution with a source link.
- Added page-specific styling in `css/beaches-coast.css` implementing a responsive hero, card layout, typography, and a small mobile media query.
- Updated `index.html` to include a navigation link to the new `beaches-coast.html` page so it is reachable from the main menu.
- Kept the new content concise and original while including clear attribution and a link to the original Tourism New Zealand page.

### Testing
- Verified the three modified/created files exist and contain expected content using a small Python check (`python - <<'PY' ...`) which confirmed file lengths and presence of the attribution link, and that check passed.
- Attempted HTML validation with `xmllint --html --noout beaches-coast.html` but `xmllint` is not installed in this environment so that check could not run.
- Performed basic file inspections (`nl`/print checks) to confirm the page and stylesheet were written and references to images/Bootstrap are present, and these inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0ff5d700833390f5107443ee6dd3)