### PR TITLE
Standardize navbar links across all pages

### DIFF
--- a/attractions.html
+++ b/attractions.html
@@ -25,34 +25,25 @@
     <!--HEADER AND NAVBAR-->
     <header>
         <!--NAVBAR-->
-        <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-            <!--NAV BRAND-->
-            <div class="navbar-header">
-                <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100"
-                        height="45" class="d-inline-block align-center" alt="LOGO"></a>
-            </div>
-            <!--NAVBAR DROPDOWN-->
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
-                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle
-            navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <!--NAVBAR MENU-->
-            <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="nav navbar-nav">
-                    <li class="nav-item"><a class="nav-link" href="index.html">Home
-                            <span class="sr-only">(current)</span></a>
-                    </li>
-                    <li class="nav-item active"><a class="nav-link" href="attractions.html">Main
-                            Attractions & Locations</a></li>
-                    <li class="nav-item"><a class="nav-link" href="history.html">New
-                            Zealands History</a></li>
-                    <li class="nav-item"><a class="nav-link" href="events.html">Coming
-                            Events</a></li>
-                    <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
-                </ul>
-            </div>
-       </nav>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+      <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
+          alt="New Zealand fern logo"></a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="nav navbar-nav">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
+          <li class="nav-item active"><a class="nav-link" href="attractions.html">Attractions <span
+                class="sr-only">(current)</span></a></li>
+          <li class="nav-item"><a class="nav-link" href="history.html">History</a></li>
+          <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+    </nav>
                <!--JUMBOTRON-->
                <div class="jumbotron jumbotron-image-attractions">
                 <div class="jumbotron-text">

--- a/beaches-coast.html
+++ b/beaches-coast.html
@@ -14,7 +14,7 @@
 
 <body>
   <header class="coast-hero">
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+        <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
       <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
           alt="New Zealand fern logo"></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"

--- a/contact.html
+++ b/contact.html
@@ -19,30 +19,25 @@
     <!--HEADER AND NAVBAR-->
     <header>
         <!--NAVBAR-->
-        <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-            <!--NAV BRAND-->
-            <div class="navbar-header">
-                <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100"
-                        height="45" class="d-inline-block align-center" alt="LOGO"></a>
-            </div>
-            <!--NAVBAR DROPDOWN-->
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
-                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <!--NAVBAR MENU-->
-            <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="nav navbar-nav">
-                    <li class="nav-item"><a class="nav-link" href="index.html">Home <span
-                                class="sr-only">(current)</span></a></li>
-                    <li class="nav-item"><a class="nav-link" href="attractions.html">Main Attractions & Locations</a>
-                    </li>
-                    <li class="nav-item"><a class="nav-link" href="history.html">New Zealands History</a></li>
-                    <li class="nav-item"><a class="nav-link" href="events.html">Coming Events</a></li>
-                    <li class="nav-item active"><a class="nav-link" href="contact.html">Contact</a></li>
-                </ul>
-            </div>
-        </nav>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+      <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
+          alt="New Zealand fern logo"></a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="nav navbar-nav">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
+          <li class="nav-item"><a class="nav-link" href="attractions.html">Attractions</a></li>
+          <li class="nav-item"><a class="nav-link" href="history.html">History</a></li>
+          <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
+          <li class="nav-item active"><a class="nav-link" href="contact.html">Contact <span
+                class="sr-only">(current)</span></a></li>
+        </ul>
+      </div>
+    </nav>
         <!--JUMBOTRON-->
         <div class="jumbotron jumbotron-image-contact">
             <div class="jumbotron-text">

--- a/events.html
+++ b/events.html
@@ -25,30 +25,25 @@
     <!--HEADER AND NAVBAR-->
     <header>
         <!--NAVBAR-->
-        <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-            <!--NAV BRAND-->
-            <div class="navbar-header">
-                <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100"
-                        height="45" class="d-inline-block align-center" alt="LOGO"></a>
-            </div>
-            <!--NAVBAR DROPDOWN-->
-            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
-                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
-            <!--NAVBAR MENU-->
-            <div class="collapse navbar-collapse" id="navbarNav">
-                <ul class="nav navbar-nav">
-                    <li class="nav-item"><a class="nav-link" href="index.html">Home<span
-                                class="sr-only">(current)</span></a></li>
-                    <li class="nav-item"><a class="nav-link" href="attractions.html">Main Attractions & Locations</a>
-                    </li>
-                    <li class="nav-item"><a class="nav-link" href="history.html">New Zealands History</a></li>
-                    <li class="nav-item active"><a class="nav-link" href="events.html">Coming Events</a></li>
-                    <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
-                </ul>
-            </div>
-        </nav>
+            <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+      <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
+          alt="New Zealand fern logo"></a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="nav navbar-nav">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
+          <li class="nav-item"><a class="nav-link" href="attractions.html">Attractions</a></li>
+          <li class="nav-item"><a class="nav-link" href="history.html">History</a></li>
+          <li class="nav-item active"><a class="nav-link" href="events.html">Events <span
+                class="sr-only">(current)</span></a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+    </nav>
         <!--JUMBOTRON-->
         <div class="jumbotron jumbotron-image-events">
             <div class="jumbotron-text">

--- a/history.html
+++ b/history.html
@@ -26,30 +26,21 @@
   <!--HEADER AND NAVBAR-->
   <header>
     <!--NAVBAR-->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-      <!--NAV BRAND-->
-      <div class="navbar-header">
-        <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
-            class="d-inline-block align-center" alt="LOGO"></a>
-      </div>
-      <!--NAVBAR DROPDOWN-->
+        <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+      <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
+          alt="New Zealand fern logo"></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
-        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle
-          navigation">
+        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <!--NAVBAR MENU-->
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="nav navbar-nav">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home
-              <span class="sr-only">(current)</span></a>
-          </li>
-          <li class="nav-item"><a class="nav-link" href="attractions.html">Main
-              Attractions & Locations</a></li>
-          <li class="nav-item active"><a class="nav-link" href="history.html">New
-              Zealands History</a></li>
-          <li class="nav-item"><a class="nav-link" href="events.html">Coming
-              Events</a></li>
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
+          <li class="nav-item"><a class="nav-link" href="attractions.html">Attractions</a></li>
+          <li class="nav-item active"><a class="nav-link" href="history.html">History <span
+                class="sr-only">(current)</span></a></li>
+          <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
           <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -25,26 +25,21 @@
   <!--HEADER AND NAVBAR-->
   <header>
     <!--NAVBAR-->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
-      <!--NAV BRAND-->
-      <div class="navbar-header">
-        <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
-            class="d-inline-block align-center" alt="LOGO"></a>
-      </div>
-      <!--NAVBAR DROPDOWN-->
+        <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+      <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
+          alt="New Zealand fern logo"></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
         aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>
-      <!--NAVBAR MENU-->
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="nav navbar-nav">
           <li class="nav-item active"><a class="nav-link" href="index.html">Home <span
                 class="sr-only">(current)</span></a></li>
-          <li class="nav-item"><a class="nav-link" href="attractions.html">Main Attractions & Locations</a></li>
-          <li class="nav-item"><a class="nav-link" href="history.html">New Zealands History</a></li>
           <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
-          <li class="nav-item"><a class="nav-link" href="events.html">Coming Events</a></li>
+          <li class="nav-item"><a class="nav-link" href="attractions.html">Attractions</a></li>
+          <li class="nav-item"><a class="nav-link" href="history.html">History</a></li>
+          <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
           <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
         </ul>
       </div>


### PR DESCRIPTION
### Motivation
- Ensure consistent navigation across the site by unifying the top navbar markup, labels and ordering on all pages for better UX and maintainability.
- Keep per-page semantics (which page is current) and accessibility (`sr-only` current text) while consolidating the structure.

### Description
- Replaced the top `<nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">` block on `index.html`, `beaches-coast.html`, `attractions.html`, `history.html`, `events.html`, and `contact.html` with a shared, consistent structure linking: Home, Beaches & Coast, Attractions, History, Events, Contact.
- Preserved the `nav-item active` class and the `(current)` screen-reader span on each page so each page still marks itself as active.
- Standardized the brand anchor and image (`href="index.html"` and `alt="New Zealand fern logo"`) and normalized the navbar markup/spacing across files.
- Changes were committed with the message `Standardize navbar links across all pages`.

### Testing
- Verified presence of the navbar marker with `rg -n "<nav class=\"navbar navbar-expand-lg navbar-dark bg-dark fixed-top\">" *.html` and inspected each nav using `sed -n '/<nav class=.../,/<\/nav>/p'` which succeeded.
- Ran a Python replacement script to update the six files and confirmed the edits with `git diff --stat` which reported the updated files successfully.
- Confirmed the expected link labels and per-page active states using `rg -n "Beaches & Coast|Attractions|History|Events|Contact" index.html beaches-coast.html attractions.html history.html events.html contact.html` and then committed the changes, all operations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef18b5ceec833397359d2de564f0b6)