### PR TITLE
Add tourism-style Home V2 layout and accompanying CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -347,3 +347,191 @@ iframe {
     content: "Link";
   }
 }
+/* HOME V2 (tourism-style homepage refresh) */
+.home-v2 {
+  color: #0c2435;
+  background: #f4f7fb;
+}
+
+.home-v2 p {
+  text-align: left;
+  color: #123;
+}
+
+.home-v2 .home-navbar {
+  background: rgba(10, 24, 38, 0.75);
+  backdrop-filter: blur(3px);
+}
+
+.home-v2 .home-navbar .nav-link {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.home-v2 .hero-banner {
+  min-height: 80vh;
+  position: relative;
+  display: flex;
+  align-items: center;
+  background-image: url("../images/home-cover.jpg");
+  background-size: cover;
+  background-position: center;
+  margin-top: 0;
+}
+
+.home-v2 .hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(95deg, rgba(7, 24, 39, 0.82), rgba(7, 24, 39, 0.2));
+}
+
+.home-v2 .hero-content {
+  position: relative;
+  z-index: 1;
+  color: #fff;
+  padding-top: 60px;
+}
+
+.home-v2 .hero-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-size: 0.8rem;
+  color: #d2eaff;
+}
+
+.home-v2 .hero-content h1 {
+  font-size: clamp(2.2rem, 5vw, 4rem);
+  margin-bottom: 0.75rem;
+}
+
+.home-v2 .hero-subtitle {
+  max-width: 600px;
+  font-size: 1.2rem;
+  margin-bottom: 1.5rem;
+  color: #e6f3ff;
+}
+
+.home-v2 .hero-actions .btn {
+  margin-right: 0.75rem;
+  margin-bottom: 0.75rem;
+  border-radius: 100px;
+  padding: 0.65rem 1.25rem;
+}
+
+.home-v2 .trip-search {
+  margin-top: -50px;
+  position: relative;
+  z-index: 2;
+}
+
+.home-v2 .search-shell {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(8, 28, 43, 0.14);
+  padding: 2rem;
+}
+
+.home-v2 .search-shell h2 {
+  font-size: 1.65rem;
+  margin-bottom: 1rem;
+}
+
+.home-v2 .search-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr auto;
+  gap: 0.75rem;
+}
+
+.home-v2 .featured-grid {
+  background: #f4f7fb;
+}
+
+.home-v2 .section-heading {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.home-v2 .section-heading h3 {
+  margin-bottom: 0.5rem;
+}
+
+.home-v2 .experience-card {
+  background: #fff;
+  border-radius: 10px;
+  overflow: hidden;
+  height: 100%;
+  box-shadow: 0 8px 20px rgba(4, 24, 44, 0.1);
+}
+
+.home-v2 .experience-card img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+}
+
+.home-v2 .experience-body {
+  padding: 1rem;
+}
+
+.home-v2 .experience-body h4 {
+  font-size: 1.2rem;
+}
+
+.home-v2 .split-highlight {
+  background: #fff;
+}
+
+.home-v2 .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  font-size: 0.76rem;
+  color: #0f5fa8;
+  margin-bottom: 0.25rem;
+}
+
+.home-v2 .facts-strip {
+  background: #0f2740;
+  color: #fff;
+}
+
+.home-v2 .facts-strip p,
+.home-v2 .facts-strip h4 {
+  color: #fff;
+}
+
+.home-v2 .home-footer {
+  background: #081725;
+  color: #dbe8f5;
+}
+
+.home-v2 .home-footer h5,
+.home-v2 .home-footer h6 {
+  color: #fff;
+}
+
+.home-v2 .footer-links a {
+  color: #dbe8f5;
+}
+
+.home-v2 .footer-links a:hover {
+  color: #fff;
+  text-decoration: none;
+}
+
+@media (max-width: 992px) {
+  .home-v2 .search-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .home-v2 .trip-search {
+    margin-top: 0;
+  }
+
+  .home-v2 .search-shell {
+    border-radius: 0;
+  }
+
+  .home-v2 .hero-banner {
+    min-height: 65vh;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
         <div class="search-shell">
           <h2>What are you interested in?</h2>
           <form class="search-grid" action="attractions.html">
-            <input type="text" class="form-control" placeholder="Search places, activities, or themes">
-            <select class="form-control">
+            <input type="text" name="q" class="form-control" placeholder="Search places, activities, or themes" aria-label="Search places">
+            <select name="style" class="form-control" aria-label="Travel style">
               <option selected>Travel style</option>
               <option>Road trip</option>
               <option>Adventure</option>

--- a/index.html
+++ b/index.html
@@ -2,30 +2,21 @@
 <html lang="en">
 
 <head>
-  <!-- Required meta tags -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>AOTEAROA | HOME</title>
 
-  <!-- Bootstrap CSS -->
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
     integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
   <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
     integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-    <link rel="stylesheet" href="css/normalize.css">
+  <link rel="stylesheet" href="css/normalize.css">
   <link rel="stylesheet" href="css/style.css">
-
-  <!--[if it IE 9]->
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js"></script>
-    <![endif]-->
 </head>
 
-<body itemscope itemtype="https://schema.org/WebPage">
-  <!--HEADER AND NAVBAR-->
-  <header>
-    <!--NAVBAR-->
-        <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
+<body class="home-v2" itemscope itemtype="https://schema.org/WebPage">
+  <header class="home-header">
+    <nav class="navbar navbar-expand-lg navbar-dark home-navbar fixed-top">
       <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
           alt="New Zealand fern logo"></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
@@ -33,9 +24,8 @@
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="nav navbar-nav">
-          <li class="nav-item active"><a class="nav-link" href="index.html">Home <span
-                class="sr-only">(current)</span></a></li>
+        <ul class="nav navbar-nav ml-auto">
+          <li class="nav-item active"><a class="nav-link" href="index.html">Home <span class="sr-only">(current)</span></a></li>
           <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
           <li class="nav-item"><a class="nav-link" href="attractions.html">Attractions</a></li>
           <li class="nav-item"><a class="nav-link" href="history.html">History</a></li>
@@ -44,100 +34,157 @@
         </ul>
       </div>
     </nav>
-    <!--JUMBOTRON-->
-    <div class="jumbotron jumbotron-image-home">
-      <div class="jumbotron-text">
-        <h1>Welcome, we are kiwis</h1>
-        <p>Land of The Long White Cloud</p>
-      </div>
-    </div>
-  </header>
-  <!--HOME PAGE INTRODUCTION-->
-  <div class="container" id="home">
-    <h3 class="display-4 lead">What brings you here?</h3>
-    <p>Are you interested in our history and how we became the kiwis? maybe you're here to look for a
-      family trip? Or you're trying to find an event that interest you? Well this is the place you want to be.
-      Its all easy to navigate and read so don't worry about any annoying or frustrating links.</p>
-    <p>
-      our New Zealand site has great information, from NZ history and how NZ became to beautiful locations all around
-      New Zealand.
-      We even took the time researching New Zealands main attractions and up-coming events just to make your life a
-      little easier if you have any questions
-      dont hesitate to send them through just go to our <a href="contact.html">contact page</a>, Enjoy.</p>
-    <!--HOME PAGE FACTS ABOUT NEW ZEALAND-->
-    <h4>Facts about New Zealand</h4>
-    <p>#1 New Zealand’s name in Maori is Aotearoa, which means ‘land of the long white cloud.’</p>
-    <p>#2 In 1990, New Zealand became the first country in the modern world to appoint an <a
-        href="http://www.stuff.co.nz/the-press/8087658/Wizard-reminisces-as-he-turns-80">Official National Wizard.</a>
-    </p>
-    <p>#3 To become a New Zealand citizen, you must swear an oath of loyalty to Queen Elizabeth.</p>
-    <p>#4 New Zealand is one of the world’s least populated countries with 4.794 million</p>
-  </div>
 
-  <div class="container" id="showcase">
-    <!--HOME PAGE CAROUSEL-->
-    <h4>Attractive photos of our land</h4>
-    <div id="slider" class="carousel slide" data-ride="carousel">
-      <ul class="carousel-indicators">
-        <li data-target="#slider" data-slide-to="0" class="active"></li>
-        <li data-target="#slider" data-slide-to="1"></li>
-        <li data-target="#slider" data-slide-to="2"></li>
-        <li data-target="#slider" data-slide-to="3"></li>
-        <li data-target="#slider" data-slide-to="4"></li>
-      </ul>
-      <!--CAROUSEL IMAGES-->
-      <div class="carousel-inner">
-        <div class="carousel-item active">
-          <img class="img" src="./images/silver-fern.jpg" alt="carousel img" width="100%" height="450">
-          <div class="carousel-caption">
-            <h3>New Zealands Silver Fern</h3>
+    <section class="hero-banner">
+      <div class="hero-overlay"></div>
+      <div class="container hero-content">
+        <p class="hero-kicker">100% Pure New Zealand</p>
+        <h1>Welcome to Aotearoa</h1>
+        <p class="hero-subtitle">Plan unforgettable adventures across mountains, coastlines, and vibrant cities.</p>
+        <div class="hero-actions">
+          <a class="btn btn-light btn-lg" href="attractions.html">Explore destinations</a>
+          <a class="btn btn-outline-light btn-lg" href="events.html">See events</a>
+        </div>
+      </div>
+    </section>
+  </header>
+
+  <main>
+    <section class="trip-search py-5">
+      <div class="container">
+        <div class="search-shell">
+          <h2>What are you interested in?</h2>
+          <form class="search-grid" action="attractions.html">
+            <input type="text" class="form-control" placeholder="Search places, activities, or themes">
+            <select class="form-control">
+              <option selected>Travel style</option>
+              <option>Road trip</option>
+              <option>Adventure</option>
+              <option>Family</option>
+            </select>
+            <button class="btn btn-primary" type="submit">Find ideas</button>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section class="featured-grid py-5">
+      <div class="container">
+        <div class="section-heading">
+          <h3>Featured must-do experiences</h3>
+          <p>Handpicked highlights inspired by New Zealand’s official tourism style.</p>
+        </div>
+        <div class="row">
+          <div class="col-md-4 mb-4">
+            <article class="experience-card">
+              <img src="images/lake-taupo.jpg" alt="Lake Taupo at sunset">
+              <div class="experience-body">
+                <h4>Great Lakes & Alpine Views</h4>
+                <p>Find hidden viewpoints and iconic walks from Taupō to the Southern Alps.</p>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-4 mb-4">
+            <article class="experience-card">
+              <img src="images/coromandel.jpg" alt="Coromandel coast">
+              <div class="experience-body">
+                <h4>Beaches & Coastal Drives</h4>
+                <p>Relax in Coromandel and discover scenic coast roads with ocean panoramas.</p>
+              </div>
+            </article>
+          </div>
+          <div class="col-md-4 mb-4">
+            <article class="experience-card">
+              <img src="images/nz-rainforest.jpg" alt="New Zealand rainforest">
+              <div class="experience-body">
+                <h4>Native Forest Adventures</h4>
+                <p>Step into lush rainforest trails, waterfalls, and rich Māori cultural stories.</p>
+              </div>
+            </article>
           </div>
         </div>
-        <div class="carousel-item">
-          <img class="img" src="./images/nz-rainforest.jpg" alt="carousel img" width="100%" height="450">
-          <div class="carousel-caption">
-            <h3>Our beautiful green rainforest</h3>
+      </div>
+    </section>
+
+    <section class="split-highlight py-5">
+      <div class="container">
+        <div class="row align-items-center">
+          <div class="col-lg-6 mb-4 mb-lg-0">
+            <img class="img-fluid rounded" src="images/silver-fern.jpg" alt="Silver fern leaf">
+          </div>
+          <div class="col-lg-6">
+            <p class="eyebrow">Travel inspiration</p>
+            <h3>Build your perfect New Zealand journey</h3>
+            <p>From vibrant cities to remote nature escapes, discover itineraries for every type of traveller. Use
+              our guides to match your pace, budget, and interests.</p>
+            <ul>
+              <li>Curated itineraries from 3 to 14 days</li>
+              <li>Seasonal recommendations and weather tips</li>
+              <li>Local events, culture, and food suggestions</li>
+            </ul>
+            <a class="btn btn-outline-primary" href="history.html">Start planning</a>
           </div>
         </div>
-        <div class="carousel-item">
-          <img class="img" src="./images/lake-taupo.jpg" alt="carousel img" width="100%" height="450">
-          <div class="carousel-caption">
-            <h3>Lake Taupos beautiful sunset</h3>
+      </div>
+    </section>
+
+    <section class="facts-strip py-5">
+      <div class="container">
+        <div class="row text-center">
+          <div class="col-md-3 col-6 mb-4 mb-md-0">
+            <h4>2 Islands</h4>
+            <p>North & South with unique landscapes.</p>
+          </div>
+          <div class="col-md-3 col-6 mb-4 mb-md-0">
+            <h4>15,000 km</h4>
+            <p>Of breathtaking coastline to explore.</p>
+          </div>
+          <div class="col-md-3 col-6">
+            <h4>100+ Trails</h4>
+            <p>Great Walks and day hikes nationwide.</p>
+          </div>
+          <div class="col-md-3 col-6">
+            <h4>Year-round</h4>
+            <p>Adventure options in every season.</p>
           </div>
         </div>
-        <div class="carousel-item">
-          <img class="img" src="./images/coromandel.jpg" alt="carousel img" width="100%" height="450">
-          <div class="carousel-caption">
-            <h3>Coromandels beach</h3>
-          </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="page-footer home-footer">
+    <div class="container py-5">
+      <div class="row">
+        <div class="col-md-4 mb-4 mb-md-0">
+          <h5>AOTEAROA</h5>
+          <p>Your local guide to discovering New Zealand’s destinations, stories, and experiences.</p>
         </div>
-        <!--CAROUSEL NEXT ARROWS-->
-        <a class="carousel-control-prev" href="#slider" data-slide="prev"><span
-            class="carousel-control-prev-icon"></span></a>
-        <a class="carousel-control-next" href="#slider" data-slide="next"><span
-            class="carousel-control-next-icon"></span></a>
+        <div class="col-md-4 mb-4 mb-md-0">
+          <h6>Explore</h6>
+          <ul class="list-unstyled footer-links">
+            <li><a href="attractions.html">Top attractions</a></li>
+            <li><a href="beaches-coast.html">Beaches & Coast</a></li>
+            <li><a href="events.html">Events calendar</a></li>
+          </ul>
+        </div>
+        <div class="col-md-4">
+          <h6>Plan</h6>
+          <ul class="list-unstyled footer-links">
+            <li><a href="history.html">History & culture</a></li>
+            <li><a href="contact.html">Contact us</a></li>
+          </ul>
+        </div>
       </div>
     </div>
-  </div>
-  <!-- Footer -->
-  <footer class="page-footer font-small bg-dark">
-    <!-- Copyright -->
-    <div class="footer-copyright text-center py-3">© 2018 Copyright:
-      <a href="https://www.facebook.com/luke.gilchrist.35">LUKE PONGA</a>
-    </div>
-    <!-- Copyright -->
+    <div class="footer-copyright text-center py-3">© 2026 AOTEAROA</div>
   </footer>
 
-  <!-- jQuery first, then Tether, then Bootstrap JS. -->
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
-    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous">
-  </script>
+    integrity="sha384-q8i/X+965DzO0rR7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
-    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous">
-  </script>
+    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
-    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous">
-  </script>
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
   <script src="scripts/main.js"></script>
 </body>
 


### PR DESCRIPTION
### Motivation
- Refresh the homepage into a tourism-style experience with a hero banner, search module and curated experience cards to better showcase destinations and itineraries.
- Replace the legacy jumbotron/carousel layout with a modern, content-first structure and visual hierarchy suitable for travel content.
- Introduce a scoped design system for the home page via a `.home-v2` namespace to avoid global style regressions.

### Description
- Reworked `index.html` to use a new `body` class `home-v2` and added a hero banner (`.hero-banner`) with overlay, kicker, title, subtitle and CTA buttons, replacing the old jumbotron and carousel markup.
- Added a trip search section (`.trip-search` / `.search-shell`) and a featured experiences grid with card components (`.experience-card`) and a split-highlight section for additional content.
- Appended a new scoped stylesheet block to `css/style.css` containing all `.home-v2` styles, including responsive rules (`@media (max-width: 992px)`), hero background, overlay, search grid, cards, facts strip and footer styles.
- Updated the navbar to `home-navbar` and adjusted layout classes (`ml-auto`) and footer content/date to align with the refreshed design and structure.

### Testing
- No automated tests are configured for this static site repository, so no automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1b0f86cc8333b24be5496e3a95b8)