### PR TITLE
Inner-pages visual refresh: new global styles and copy fixes

### DIFF
--- a/attractions.html
+++ b/attractions.html
@@ -54,7 +54,7 @@
     </header>
        <!--BREADCRUMB-->
         <div class="container">
-            <p>Main Attractions or Popular Locations</p>
+            <p>Browse attractions and map locations</p>
             <ul class="breadcrumb">
                 <li class="breadcrumb-item active"><a href="#attractions">Main Attractions</a></li>
                 <li class="breadcrumb-item"><a href="#locations">New Zealand Locations</a></li>
@@ -207,7 +207,7 @@
 
     <!--LOCATIONS MAP-->
     <div class="container" id="locations">
-        <h3>New Zealands Map</h3>
+        <h3>New Zealand Map</h3>
         <div class="row">
             <div class="col col-sm-12 col-md-12 col-lg-12">
                 <iframe width="100%" height="576" src="https://maphub.net/embed/58969?button=0&directions=1&panel=1"
@@ -217,7 +217,7 @@
     </div>
 
     <div class="container">
-        <p>Main Attractions or Popular Locations</p>
+        <p>Browse attractions and map locations</p>
         <ul class="breadcrumb">
             <li class="breadcrumb-item active"><a href="#attractions">Main Attractions</a></li>
             <li class="breadcrumb-item"><a href="#locations">New Zealand Locations</a></li>

--- a/css/style.css
+++ b/css/style.css
@@ -536,3 +536,156 @@ iframe {
     min-height: 65vh;
   }
 }
+
+/* GLOBAL TOURISM REFRESH (all inner pages) */
+.home-v2 {
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+.home-v2 main,
+.home-v2 #attractions,
+.home-v2 #events,
+.home-v2 #history,
+.home-v2 #contact,
+.home-v2 #locations {
+  margin-top: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.home-v2 .home-navbar {
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 6px 20px rgba(2, 20, 35, 0.2);
+}
+
+.home-v2 .home-navbar .nav-link {
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+}
+
+.home-v2 .home-navbar .nav-item.active .nav-link,
+.home-v2 .home-navbar .nav-link:hover {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
+.home-v2 .jumbotron {
+  min-height: 52vh;
+  margin-bottom: 0;
+  display: flex;
+  align-items: center;
+}
+
+.home-v2 .jumbotron-text,
+.home-v2 .jumbotron-text p {
+  display: block;
+  position: relative;
+  padding: 6.5rem 2rem 2rem;
+  max-width: 980px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.home-v2 .jumbotron-text h1 {
+  color: #fff;
+  text-shadow: 0 6px 28px rgba(0, 0, 0, 0.45);
+  font-size: clamp(2rem, 5vw, 3.5rem);
+}
+
+.home-v2 .breadcrumb {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 8px 18px rgba(10, 28, 44, 0.08);
+}
+
+.home-v2 #attractions .card {
+  width: 100% !important;
+  height: 100%;
+  border: 0;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 10px 24px rgba(9, 33, 54, 0.1);
+}
+
+.home-v2 #attractions .card-img-top,
+.home-v2 #attractions .card img {
+  height: 220px;
+  object-fit: cover;
+}
+
+.home-v2 h2.card-title {
+  border-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.home-v2 p.card-text {
+  color: #22384a;
+}
+
+.home-v2 #attractions .btn-dark {
+  border-radius: 999px;
+  padding-inline: 1rem;
+  background: #0b5ea8;
+  border-color: #0b5ea8;
+}
+
+.home-v2 #events table {
+  width: 100%;
+  background: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 10px 24px rgba(9, 33, 54, 0.1);
+}
+
+.home-v2 #events th {
+  background: #0d3a63;
+  color: #fff;
+  padding: 0.85rem;
+}
+
+.home-v2 #events td {
+  background: #fff;
+  padding: 0.75rem;
+  border-bottom: 1px solid #e8edf2;
+}
+
+.home-v2 #history .row,
+.home-v2 #contact .row {
+  background: #fff;
+  border-radius: 14px;
+  padding: 1.25rem;
+  box-shadow: 0 10px 24px rgba(9, 33, 54, 0.08);
+}
+
+.home-v2 #contact form {
+  margin-top: 0;
+}
+
+.home-v2 #contact .form-control {
+  background: #f4f8fc;
+  border: 1px solid #d6e2ee;
+  border-radius: 8px;
+  color: #123;
+}
+
+.home-v2 #contact form .submit {
+  background: #0b5ea8;
+  color: #fff;
+  border-radius: 999px;
+  letter-spacing: 0;
+}
+
+.home-v2 #contact form .submit:hover {
+  background: #084b85;
+}
+
+@media (max-width: 991px) {
+  .home-v2 .jumbotron-text,
+  .home-v2 .jumbotron-text p {
+    padding-top: 7rem;
+    text-align: left;
+  }
+
+  .home-v2 .search-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/events.html
+++ b/events.html
@@ -52,7 +52,7 @@
         </div>
     </header>
     <div class="container" id="events">
-        <h3 class="display-4 lead">Welcome, we have create a list of up upcoming events around New Zealand</h3>
+        <h3 class="display-4 lead">Plan around signature events and festivals across New Zealand</h3>
         <table role="table">
             <thead role="rowgroup">
                 <tr role="row">


### PR DESCRIPTION
### Motivation
- Refresh the visual style across inner pages to a consistent, modern look and improved responsiveness.  
- Standardize card, jumbotron, navbar and form visuals so attractions, events, history and contact pages match the new design language.  
- Fix copy/typo issues and improve hero/table headings for clarity and tone.

### Description
- Added a new `/* GLOBAL TOURISM REFRESH (all inner pages) */` stylesheet block in `css/style.css` implementing typography, navbar, jumbotron, breadcrumb, card, table and contact form styles plus responsive adjustments.  
- Updated attractions page copy in `attractions.html`: changed breadcrumb text to "Browse attractions and map locations" (two occurrences) and fixed the map heading to "New Zealand Map".  
- Improved events page hero copy in `events.html` to "Plan around signature events and festivals across New Zealand".  
- Tweaked card sizing and button look (e.g. `.home-v2 #attractions .card`, `.home-v2 #attractions .btn-dark`) to better fit the refreshed layout.

### Testing
- Ran static CSS checks with `stylelint` against the modified `css/style.css` and no lint errors were reported.  
- Validated updated HTML with `htmlhint`/HTML validator checks and no errors were reported.  
- No automated unit tests were changed or required for these presentational and content updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1b0f86cc8333b24be5496e3a95b8)