### PR TITLE
Brand refresh, UI style additions, and events page refactor

### DIFF
--- a/attractions.html
+++ b/attractions.html
@@ -227,7 +227,7 @@
     <!-- Footer -->
     <footer class="page-footer home-footer">
         <!-- Copyright -->
-        <div class="footer-copyright text-center py-3">Pure New Zealand ©2026
+        <div class="footer-copyright text-center py-3">Pure New Zealand © 2026
         </div>
         <!-- Copyright -->
     </footer>

--- a/attractions.html
+++ b/attractions.html
@@ -54,7 +54,7 @@
     </header>
        <!--BREADCRUMB-->
         <div class="container">
-            <p>Main Attractions or Popular Locations</p>
+            <p>Browse attractions and map locations</p>
             <ul class="breadcrumb">
                 <li class="breadcrumb-item active"><a href="#attractions">Main Attractions</a></li>
                 <li class="breadcrumb-item"><a href="#locations">New Zealand Locations</a></li>
@@ -207,7 +207,7 @@
 
     <!--LOCATIONS MAP-->
     <div class="container" id="locations">
-        <h3>New Zealands Map</h3>
+        <h3>New Zealand Map</h3>
         <div class="row">
             <div class="col col-sm-12 col-md-12 col-lg-12">
                 <iframe width="100%" height="576" src="https://maphub.net/embed/58969?button=0&directions=1&panel=1"
@@ -217,7 +217,7 @@
     </div>
 
     <div class="container">
-        <p>Main Attractions or Popular Locations</p>
+        <p>Browse attractions and map locations</p>
         <ul class="breadcrumb">
             <li class="breadcrumb-item active"><a href="#attractions">Main Attractions</a></li>
             <li class="breadcrumb-item"><a href="#locations">New Zealand Locations</a></li>
@@ -227,7 +227,7 @@
     <!-- Footer -->
     <footer class="page-footer home-footer">
         <!-- Copyright -->
-        <div class="footer-copyright text-center py-3">© 2026 AOTEAROA
+        <div class="footer-copyright text-center py-3">Pure New Zealand ©2026
         </div>
         <!-- Copyright -->
     </footer>

--- a/beaches-coast.html
+++ b/beaches-coast.html
@@ -117,7 +117,7 @@
   </main>
 
   <footer class="page-footer home-footer text-light text-center py-3">
-    Pure New Zealand ©2026
+    Pure New Zealand © 2026
   </footer>
 
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"

--- a/beaches-coast.html
+++ b/beaches-coast.html
@@ -117,7 +117,7 @@
   </main>
 
   <footer class="page-footer home-footer text-light text-center py-3">
-    © 2026 AOTEAROA
+    Pure New Zealand ©2026
   </footer>
 
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"

--- a/contact.html
+++ b/contact.html
@@ -67,7 +67,7 @@
     <!-- Footer -->
     <footer class="page-footer home-footer">
         <!-- Copyright -->
-        <div class="footer-copyright text-center py-3">Pure New Zealand ©2026
+        <div class="footer-copyright text-center py-3">Pure New Zealand © 2026
         </div>
         <!-- Copyright -->
     </footer>

--- a/contact.html
+++ b/contact.html
@@ -67,7 +67,7 @@
     <!-- Footer -->
     <footer class="page-footer home-footer">
         <!-- Copyright -->
-        <div class="footer-copyright text-center py-3">© 2026 AOTEAROA
+        <div class="footer-copyright text-center py-3">Pure New Zealand ©2026
         </div>
         <!-- Copyright -->
     </footer>

--- a/css/style.css
+++ b/css/style.css
@@ -536,3 +536,211 @@ iframe {
     min-height: 65vh;
   }
 }
+
+/* GLOBAL TOURISM REFRESH (all inner pages) */
+.home-v2 {
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+.home-v2 main,
+.home-v2 #attractions,
+.home-v2 #events,
+.home-v2 #history,
+.home-v2 #contact,
+.home-v2 #locations {
+  margin-top: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.home-v2 .home-navbar {
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 6px 20px rgba(2, 20, 35, 0.2);
+}
+
+.home-v2 .home-navbar .nav-link {
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+}
+
+.home-v2 .home-navbar .nav-item.active .nav-link,
+.home-v2 .home-navbar .nav-link:hover {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
+.home-v2 .jumbotron {
+  min-height: 52vh;
+  margin-bottom: 0;
+  display: flex;
+  align-items: center;
+}
+
+.home-v2 .jumbotron-text,
+.home-v2 .jumbotron-text p {
+  display: block;
+  position: relative;
+  padding: 6.5rem 2rem 2rem;
+  max-width: 980px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.home-v2 .jumbotron-text h1 {
+  color: #fff;
+  text-shadow: 0 6px 28px rgba(0, 0, 0, 0.45);
+  font-size: clamp(2rem, 5vw, 3.5rem);
+}
+
+.home-v2 .breadcrumb {
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 8px 18px rgba(10, 28, 44, 0.08);
+}
+
+.home-v2 #attractions .card {
+  width: 100% !important;
+  height: 100%;
+  border: 0;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: 0 10px 24px rgba(9, 33, 54, 0.1);
+}
+
+.home-v2 #attractions .card-img-top,
+.home-v2 #attractions .card img {
+  height: 220px;
+  object-fit: cover;
+}
+
+.home-v2 h2.card-title {
+  border-bottom: 0;
+  font-size: 1.35rem;
+}
+
+.home-v2 p.card-text {
+  color: #22384a;
+}
+
+.home-v2 #attractions .btn-dark {
+  border-radius: 999px;
+  padding-inline: 1rem;
+  background: #0b5ea8;
+  border-color: #0b5ea8;
+}
+
+.home-v2 #events table {
+  width: 100%;
+  background: #fff;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 10px 24px rgba(9, 33, 54, 0.1);
+}
+
+.home-v2 #events th {
+  background: #0d3a63;
+  color: #fff;
+  padding: 0.85rem;
+}
+
+.home-v2 #events td {
+  background: #fff;
+  padding: 0.75rem;
+  border-bottom: 1px solid #e8edf2;
+}
+
+.home-v2 #history .row,
+.home-v2 #contact .row {
+  background: #fff;
+  border-radius: 14px;
+  padding: 1.25rem;
+  box-shadow: 0 10px 24px rgba(9, 33, 54, 0.08);
+}
+
+.home-v2 #contact form {
+  margin-top: 0;
+}
+
+.home-v2 #contact .form-control {
+  background: #f4f8fc;
+  border: 1px solid #d6e2ee;
+  border-radius: 8px;
+  color: #123;
+}
+
+.home-v2 #contact form .submit {
+  background: #0b5ea8;
+  color: #fff;
+  border-radius: 999px;
+  letter-spacing: 0;
+}
+
+.home-v2 #contact form .submit:hover {
+  background: #084b85;
+}
+
+@media (max-width: 991px) {
+  .home-v2 .jumbotron-text,
+  .home-v2 .jumbotron-text p {
+    padding-top: 7rem;
+    text-align: left;
+  }
+
+  .home-v2 .search-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* EVENTS PAGE RESPONSIVE LAYOUT */
+.home-v2 #events .events-intro {
+  margin-bottom: 1.5rem;
+}
+
+.home-v2 #events .events-intro p {
+  max-width: 780px;
+  margin: 0 auto;
+  color: #365269;
+}
+
+.home-v2 #events .events-grid {
+  margin-top: 0.5rem;
+}
+
+.home-v2 #events .event-card {
+  background: #fff;
+  border-radius: 14px;
+  padding: 1rem;
+  box-shadow: 0 10px 24px rgba(9, 33, 54, 0.1);
+  display: flex;
+  flex-direction: column;
+}
+
+.home-v2 #events .event-date {
+  display: inline-block;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #0b5ea8;
+  margin-bottom: 0.5rem;
+}
+
+.home-v2 #events .event-card h4 {
+  font-size: 1.2rem;
+  margin-bottom: 0.6rem;
+}
+
+.home-v2 #events .event-location {
+  color: #32506a;
+  margin-bottom: 1rem;
+}
+
+.home-v2 #events .event-card .btn-dark {
+  margin-top: auto;
+  border-radius: 999px;
+  background: #0b5ea8;
+  border-color: #0b5ea8;
+}
+
+.home-v2 #events .event-card .btn-dark:hover {
+  background: #084b85;
+  border-color: #084b85;
+}

--- a/events.html
+++ b/events.html
@@ -54,7 +54,7 @@
 
     <main class="container" id="events">
         <div class="events-intro text-center">
-            <h3 class="display-4 lead">Plan around signature events and festivals across New Zealand</h3>
+            <h3 class="display-4">Plan around signature events and festivals across New Zealand</h3>
             <p>Find notable exhibitions, conferences, and entertainment events with quick links for details.</p>
         </div>
 

--- a/events.html
+++ b/events.html
@@ -113,7 +113,7 @@
       <!-- Footer -->
   <footer class="page-footer home-footer">
         <!-- Copyright -->
-        <div class="footer-copyright text-center py-3">Pure New Zealand ©2026</div>
+        <div class="footer-copyright text-center py-3">Pure New Zealand © 2026</div>
         <!-- Copyright -->
       </footer>
 

--- a/events.html
+++ b/events.html
@@ -51,69 +51,69 @@
             </div>
         </div>
     </header>
-    <div class="container" id="events">
-        <h3 class="display-4 lead">Welcome, we have create a list of up upcoming events around New Zealand</h3>
-        <table role="table">
-            <thead role="rowgroup">
-                <tr role="row">
-                    <th role="columnheader">#</th>
-                    <th role="columnheader">Event</th>
-                    <th role="columnheader">Date</th>
-                    <th role="columnheader">Location</th>
-                    <th role="columnheader">Link</th>
-                </tr>
-            </thead>
-            <tbody role="rowgroup">
-                <tr role="row">
-                    <td role="cell">1</td>
-                    <td role="cell">Careers Expo Wellington Exhibition</td>
-                    <td role="cell">21–22 Jun 2019</td>
-                    <td role="cell">4 Queens Wharf, Wellington, 6011</td>
-                    <td role="cell"><a class="btn btn-dark" style="width:100%; height:35px;" href="https://www.careersexpo.org.nz/expos/wellington-2019">Interested?</a></td>
-                </tr>
-                <tr role="row">
-                    <td role="cell">2</td>
-                    <td role="cell">Logo Autumn Gift & Homeware Fair Exhibition</td>
-                    <td role="cell">25 - 27 August 2019</td>
-                    <td role="cell">152 Beaumont Street Westhaven Auckland 1010</td>
-                    <td role="cell"><a class="btn btn-dark" style="width:100%; height:35px;" href="http://www.giftfairs.co.nz/">Interested?</a></td>
-                </tr>
-                <tr role="row">
-                    <td role="cell">3</td>
-                    <td role="cell">International Conference on Science, Engineering & Technology</td>
-                    <td role="cell">05-06 Jun 2019</td>
-                    <td role="cell">The Surrey Hotel, Auckland</td>
-                    <td role="cell"><a class="btn btn-dark" style="width:100%; height:35px;" href="https://10times.com/icset-auckland">Interested?</a></td>
-                </tr>
-                <tr role="row">
-                    <td role="cell">4</td>
-                    <td role="cell">Software Testing Symposium</td>
-                    <td role="cell">06 Jun 2019</td>
-                    <td role="cell"> Hotel Mercure Auckland</td>
-                    <td role="cell"><a class="btn btn-dark" style="width:100%; height:35px;" href="https://www.testingmind.com/event/software-testing-symposium-2019-auckland/">Interested?</a></td>
-                </tr>
-                <tr role="row">
-                    <td role="cell">5</td>
-                    <td role="cell">Tauranga Armageddon</td>
-                    <td role="cell"> 08-09 Jun 2019</td>
-                    <td role="cell"> ASB Baypark Stadium Tauranga</td>
-                    <td role="cell"><a class="btn btn-dark" style="width:100%; height:35px;" href="https://10times.com/armageddon">Interested?</a></td>
-                </tr>   
-                <tr role="row">
-                    <td role="cell">6</td>
-                    <td role="cell">International Vape Expo Oceania Show</td>
-                    <td role="cell"> 07-08 Dec 2019</td>
-                    <td role="cell">ASB Showgrounds, Auckland</td>
-                    <td role="cell"><a class="btn btn-dark" style="width:100%; height:30px;" href="https://10times.com/iveo">Interested?</a></td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
+
+    <main class="container" id="events">
+        <div class="events-intro text-center">
+            <h3 class="display-4 lead">Plan around signature events and festivals across New Zealand</h3>
+            <p>Find notable exhibitions, conferences, and entertainment events with quick links for details.</p>
+        </div>
+
+        <section class="row events-grid" aria-label="Upcoming events list">
+            <div class="col-sm-12 col-md-6 col-xl-4 mb-4 d-flex">
+                <article class="event-card w-100">
+                    <p class="event-date">21–22 Jun 2019</p>
+                    <h4>Careers Expo Wellington Exhibition</h4>
+                    <p class="event-location">4 Queens Wharf, Wellington, 6011</p>
+                    <a class="btn btn-dark btn-block" href="https://www.careersexpo.org.nz/expos/wellington-2019">Interested?</a>
+                </article>
+            </div>
+            <div class="col-sm-12 col-md-6 col-xl-4 mb-4 d-flex">
+                <article class="event-card w-100">
+                    <p class="event-date">25–27 Aug 2019</p>
+                    <h4>Logo Autumn Gift & Homeware Fair Exhibition</h4>
+                    <p class="event-location">152 Beaumont Street Westhaven, Auckland 1010</p>
+                    <a class="btn btn-dark btn-block" href="http://www.giftfairs.co.nz/">Interested?</a>
+                </article>
+            </div>
+            <div class="col-sm-12 col-md-6 col-xl-4 mb-4 d-flex">
+                <article class="event-card w-100">
+                    <p class="event-date">05–06 Jun 2019</p>
+                    <h4>International Conference on Science, Engineering & Technology</h4>
+                    <p class="event-location">The Surrey Hotel, Auckland</p>
+                    <a class="btn btn-dark btn-block" href="https://10times.com/icset-auckland">Interested?</a>
+                </article>
+            </div>
+            <div class="col-sm-12 col-md-6 col-xl-4 mb-4 d-flex">
+                <article class="event-card w-100">
+                    <p class="event-date">06 Jun 2019</p>
+                    <h4>Software Testing Symposium</h4>
+                    <p class="event-location">Hotel Mercure Auckland</p>
+                    <a class="btn btn-dark btn-block" href="https://www.testingmind.com/event/software-testing-symposium-2019-auckland/">Interested?</a>
+                </article>
+            </div>
+            <div class="col-sm-12 col-md-6 col-xl-4 mb-4 d-flex">
+                <article class="event-card w-100">
+                    <p class="event-date">08–09 Jun 2019</p>
+                    <h4>Tauranga Armageddon</h4>
+                    <p class="event-location">ASB Baypark Stadium, Tauranga</p>
+                    <a class="btn btn-dark btn-block" href="https://10times.com/armageddon">Interested?</a>
+                </article>
+            </div>
+            <div class="col-sm-12 col-md-6 col-xl-4 mb-4 d-flex">
+                <article class="event-card w-100">
+                    <p class="event-date">07–08 Dec 2019</p>
+                    <h4>International Vape Expo Oceania Show</h4>
+                    <p class="event-location">ASB Showgrounds, Auckland</p>
+                    <a class="btn btn-dark btn-block" href="https://10times.com/iveo">Interested?</a>
+                </article>
+            </div>
+        </section>
+    </main>
 
       <!-- Footer -->
   <footer class="page-footer home-footer">
         <!-- Copyright -->
-        <div class="footer-copyright text-center py-3">© 2026 AOTEAROA</div>
+        <div class="footer-copyright text-center py-3">Pure New Zealand ©2026</div>
         <!-- Copyright -->
       </footer>
 

--- a/history.html
+++ b/history.html
@@ -131,7 +131,7 @@
   <!-- Footer -->
   <footer class="page-footer home-footer">
     <!-- Copyright -->
-    <div class="footer-copyright text-center py-3">Pure New Zealand ©2026
+    <div class="footer-copyright text-center py-3">Pure New Zealand © 2026
     </div>
     <!-- Copyright -->
   </footer>

--- a/history.html
+++ b/history.html
@@ -131,7 +131,7 @@
   <!-- Footer -->
   <footer class="page-footer home-footer">
     <!-- Copyright -->
-    <div class="footer-copyright text-center py-3">© 2026 AOTEAROA
+    <div class="footer-copyright text-center py-3">Pure New Zealand ©2026
     </div>
     <!-- Copyright -->
   </footer>

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
     <div class="container py-5">
       <div class="row">
         <div class="col-md-4 mb-4 mb-md-0">
-          <h5>AOTEAROA</h5>
+          <h5>Pure New Zealand</h5>
           <p>Your local guide to discovering New Zealand’s destinations, stories, and experiences.</p>
         </div>
         <div class="col-md-4 mb-4 mb-md-0">
@@ -176,7 +176,7 @@
         </div>
       </div>
     </div>
-    <div class="footer-copyright text-center py-3">© 2026 AOTEAROA</div>
+    <div class="footer-copyright text-center py-3">Pure New Zealand ©2026</div>
   </footer>
 
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
         </div>
       </div>
     </div>
-    <div class="footer-copyright text-center py-3">Pure New Zealand ©2026</div>
+    <div class="footer-copyright text-center py-3">Pure New Zealand © 2026</div>
   </footer>
 
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"


### PR DESCRIPTION
### Motivation
- Unify site branding and footer copy to use the `Pure New Zealand` name across pages for consistency.
- Modernize the internal page look-and-feel with a compact theme and improved responsive UI components.
- Improve accessibility and usability of the events listing by moving from a dense table to a responsive card/grid layout.

### Description
- Added a global UI refresh block to `css/style.css` (commented `GLOBAL TOURISM REFRESH`) introducing `.home-v2` styles for navbar, jumbotron, breadcrumb, cards, events grid, and contact form controls.
- Rebranded visible site text across templates by replacing `AOTEAROA` with `Pure New Zealand` in `index.html`, `attractions.html`, `events.html`, `contact.html`, `history.html`, and `beaches-coast.html`, and updated a few headings and breadcrumb copy in `attractions.html`.
- Refactored `events.html` to replace the HTML table with semantic, accessible markup using `<main>`, `<section>`, and `<article>` and implemented a responsive card/grid layout for each event with preserved external links.
- Minor updates include adding a `scripts/contact-form.php` script include in `contact.html` and small copy/heading fixes such as changing "New Zealands Map" to "New Zealand Map" in `attractions.html`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef1b0f86cc8333b24be5496e3a95b8)