### PR TITLE
Add Mapbox map container and initialization to attractions page

### DIFF
--- a/attractions.html
+++ b/attractions.html
@@ -205,13 +205,10 @@
 
     <!--LOCATIONS MAP-->
     <div class="container" id="locations">
-        <h3>New Zealand Map</h3>
-        <div class="row">
-            <div class="col col-sm-12 col-md-12 col-lg-12">
-                <iframe width="100%" height="576" src="https://maphub.net/embed/58969?button=0&directions=1&panel=1"
-                    frameborder="0"></iframe>
-            </div>
-        </div>
+        <h3 class="display-4 lead text-center">New Zealand Locations</h3>
+        <p class="sub-heading">Explore attractions across Aotearoa</p>
+
+        <div id="map"></div>
     </div>
 
     <div class="container">
@@ -239,6 +236,87 @@
     </script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous">
+    </script>
+    <link href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css" rel="stylesheet" />
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+
+    <script>
+        mapboxgl.accessToken = "YOURMAPBOXACCESS_TOKEN";
+
+        const attractions = [{
+                name: "Abel Tasman National Park",
+                coords: [172.9, -40.8333]
+            },
+            {
+                name: "Waitomo Glowworm Caves",
+                coords: [175.1036, -38.2608]
+            },
+            {
+                name: "Rainbow's End",
+                coords: [174.8840, -36.9940]
+            },
+            {
+                name: "Shotover Canyon Swing",
+                coords: [168.6611, -45.0306]
+            },
+            {
+                name: "Huka Falls",
+                coords: [176.0897, -38.6495]
+            },
+            {
+                name: "Air Force Museum of New Zealand",
+                coords: [172.5477, -43.5466]
+            },
+            {
+                name: "Te Papa Tongarewa",
+                coords: [174.7821, -41.2905]
+            },
+            {
+                name: "Marokopa Falls",
+                coords: [174.8518, -38.2615]
+            },
+            {
+                name: "Splash Planet",
+                coords: [176.8636, -39.6440]
+            },
+            {
+                name: "SEA LIFE Kelly Tarlton's Aquarium",
+                coords: [174.8172, -36.8458]
+            }
+        ];
+
+        const map = new mapboxgl.Map({
+            container: "map",
+            style: "mapbox://styles/mapbox/outdoors-v12",
+            center: [173.5, -41],
+            zoom: 4.6
+        });
+
+        map.addControl(new mapboxgl.NavigationControl(), "top-right");
+
+        map.on("load", () => {
+            const bounds = new mapboxgl.LngLatBounds();
+
+            attractions.forEach(place => {
+                bounds.extend(place.coords);
+
+                new mapboxgl.Marker({
+                        color: "#000"
+                    })
+                    .setLngLat(place.coords)
+                    .setPopup(
+                        new mapboxgl.Popup({
+                            offset: 20
+                        }).setHTML(`<strong>${place.name}</strong>`)
+                    )
+                    .addTo(map);
+            });
+
+            map.fitBounds(bounds, {
+                padding: 60,
+                maxZoom: 10
+            });
+        });
     </script>
     <script src="scripts/main.js"></script>
 </body>

--- a/css/style.css
+++ b/css/style.css
@@ -154,6 +154,13 @@ iframe {
   border: 3px solid;
 }
 
+#map {
+  width: 100%;
+  height: 500px;
+  border: 3px solid black;
+  margin: 20px auto;
+}
+
 /*ATTRACTIONS & LOCATIONS STYLE END*/
 
 /* HISTORY STYLE*/


### PR DESCRIPTION
### Motivation
- Replace the embedded static iframe with an interactive Mapbox map to align with the page breadcrumb anchor and section flow and to provide marker-driven location details. 
- Preserve the previous iframe visual styling and spacing so the new map integrates with the existing layout.

### Description
- Replaced the Locations iframe in `attractions.html` with a map container and updated heading/subheading (`<div id="map"></div>` and `h3`/`p.sub-heading`).
- Added Mapbox GL CSS and JS includes and inserted an initialization script before `</body>` that sets a placeholder `mapboxgl.accessToken`, defines the `attractions` dataset, initializes the map, adds navigation controls, markers with popups, and auto-fits bounds.
- Added `#map` styles to `css/style.css` (width, height, 3px border, margin) to match prior iframe presentation.
- Changes were committed to the branch (commit message: `Replace attractions iframe with Mapbox map container`).

### Testing
- Verified the code changes with `git diff -- attractions.html css/style.css` and inspected the diff output successfully. 
- Committed the changes with `git commit` and confirmed the commit was created successfully. 
- Inspected the updated files using `nl -ba attractions.html` and `nl -ba css/style.css` to confirm the inserted map container, Mapbox includes, initialization script, and CSS block. 
- Ran `git status --short` which reported a clean working tree after the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef31feb4dc8333a4d5832524ea51e6)