### PR TITLE
Add Mapbox map container, styles, and initialization to attractions page

### DIFF
--- a/attractions.html
+++ b/attractions.html
@@ -205,13 +205,10 @@
 
     <!--LOCATIONS MAP-->
     <div class="container" id="locations">
-        <h3>New Zealand Map</h3>
-        <div class="row">
-            <div class="col col-sm-12 col-md-12 col-lg-12">
-                <iframe width="100%" height="576" src="https://maphub.net/embed/58969?button=0&directions=1&panel=1"
-                    frameborder="0"></iframe>
-            </div>
-        </div>
+        <h3 class="display-4 lead text-center">New Zealand Locations</h3>
+        <p class="sub-heading">Explore attractions across Aotearoa</p>
+
+        <div id="map"></div>
     </div>
 
     <div class="container">
@@ -241,6 +238,55 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous">
     </script>
     <script src="scripts/main.js"></script>
+
+    <link
+        href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css"
+        rel="stylesheet">
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+
+    <script>
+        mapboxgl.accessToken = "YOURMAPBOXACCESS_TOKEN";
+
+        const attractions = [
+            { name: "Abel Tasman National Park", coords: [172.9, -40.8333] },
+            { name: "Waitomo Glowworm Caves", coords: [175.1036, -38.2608] },
+            { name: "Rainbow's End", coords: [174.8840, -36.9940] },
+            { name: "Shotover Canyon Swing", coords: [168.6611, -45.0306] },
+            { name: "Huka Falls", coords: [176.0897, -38.6495] },
+            { name: "Air Force Museum of New Zealand", coords: [172.5477, -43.5466] },
+            { name: "Te Papa Tongarewa", coords: [174.7821, -41.2905] },
+            { name: "Marokopa Falls", coords: [174.8518, -38.2615] },
+            { name: "Splash Planet", coords: [176.8636, -39.6440] },
+            { name: "SEA LIFE Kelly Tarlton's Aquarium", coords: [174.8172, -36.8458] }
+        ];
+
+        const map = new mapboxgl.Map({
+            container: "map",
+            style: "mapbox://styles/mapbox/outdoors-v12",
+            center: [173.5, -41],
+            zoom: 4.6
+        });
+
+        map.addControl(new mapboxgl.NavigationControl(), "top-right");
+
+        map.on("load", () => {
+            const bounds = new mapboxgl.LngLatBounds();
+
+            attractions.forEach(place => {
+                bounds.extend(place.coords);
+
+                new mapboxgl.Marker({ color: "#000" })
+                    .setLngLat(place.coords)
+                    .setPopup(
+                        new mapboxgl.Popup({ offset: 20 })
+                            .setHTML(`<strong>${place.name}</strong>`)
+                    )
+                    .addTo(map);
+            });
+
+            map.fitBounds(bounds, { padding: 60, maxZoom: 10 });
+        });
+    </script>
 </body>
 
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -760,3 +760,11 @@ iframe {
   background: #084b85;
   border-color: #084b85;
 }
+
+
+#map {
+  width: 100%;
+  height: 500px;
+  border: 3px solid black;
+  margin: 20px auto;
+}


### PR DESCRIPTION
### Motivation
- Replace the static embedded iframe in the Locations section with an interactive Mapbox map anchored to the existing `#locations` breadcrumb target. 
- Provide a consistent visual treatment matching existing iframe borders and spacing so the new map fits the page layout.
- Add client-side initialization and attraction marker data so the map immediately shows relevant POIs for New Zealand.

### Description
- Replaced the old iframe block in `attractions.html` with the requested container markup including `<h3 class="display-4 lead text-center">`, a `p.sub-heading`, and `<div id="map"></div>` as the map anchor. 
- Appended Mapbox GL JS CSS and JS includes and inserted a Mapbox initialization script before `</body>`, which creates the map, adds navigation controls, places markers from the provided `attractions` dataset, attaches popups, and fits the map to bounds. 
- Fixed popup rendering to use a template literal (`setHTML(`<strong>${place.name}</strong>`)`) so attraction names appear correctly. 
- Added `#map` styling to `css/style.css` to match the project's border and spacing (`width`, `height`, `border`, `margin`). 
- Left a placeholder token `YOURMAPBOXACCESS_TOKEN` in the script which must be replaced with a real Mapbox access token for the map to render in browsers.

### Testing
- Ran a whitespace/error check using `diff --check` which completed without errors. 
- Verified repository status with `status --short` to ensure only the intended files were modified. 
- Confirmed the modified files contain the new markup, scripts, and `#map` CSS rule by inspecting the diffs; no automated browser rendering tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef31feb4dc8333a4d5832524ea51e6)