### PR TITLE
Add Mapbox map with attractions markers and config example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Local secrets
+scripts/mapbox-config.js

--- a/attractions.html
+++ b/attractions.html
@@ -205,13 +205,10 @@
 
     <!--LOCATIONS MAP-->
     <div class="container" id="locations">
-        <h3>New Zealand Map</h3>
-        <div class="row">
-            <div class="col col-sm-12 col-md-12 col-lg-12">
-                <iframe width="100%" height="576" src="https://maphub.net/embed/58969?button=0&directions=1&panel=1"
-                    frameborder="0"></iframe>
-            </div>
-        </div>
+        <h3 class="display-4 lead text-center">New Zealand Locations</h3>
+        <p class="sub-heading">Explore attractions across Aotearoa</p>
+
+        <div id="map"></div>
     </div>
 
     <div class="container">
@@ -241,6 +238,66 @@
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous">
     </script>
     <script src="scripts/main.js"></script>
+    <link
+        href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css"
+        rel="stylesheet"
+    />
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
+    <script src="scripts/mapbox-config.js"></script>
+
+    <script>
+      const mapboxToken = window.MAPBOX_ACCESS_TOKEN;
+
+      if (!mapboxToken) {
+        console.error("Mapbox token missing. Add scripts/mapbox-config.js from scripts/mapbox-config.example.js.");
+      }
+
+      mapboxgl.accessToken = mapboxToken || "";
+
+      const attractions = [
+        { name: "Abel Tasman National Park", coords: [172.9, -40.8333] },
+        { name: "Waitomo Glowworm Caves", coords: [175.1036, -38.2608] },
+        { name: "Rainbow's End", coords: [174.8840, -36.9940] },
+        { name: "Shotover Canyon Swing", coords: [168.6611, -45.0306] },
+        { name: "Huka Falls", coords: [176.0897, -38.6495] },
+        { name: "Air Force Museum of New Zealand", coords: [172.5477, -43.5466] },
+        { name: "Te Papa Tongarewa", coords: [174.7821, -41.2905] },
+        { name: "Marokopa Falls", coords: [174.8518, -38.2615] },
+        { name: "Splash Planet", coords: [176.8636, -39.6440] },
+        { name: "SEA LIFE Kelly Tarlton's Aquarium", coords: [174.8172, -36.8458] }
+      ];
+
+      if (!mapboxToken) {
+        return;
+      }
+
+      const map = new mapboxgl.Map({
+        container: "map",
+        style: "mapbox://styles/mapbox/outdoors-v12",
+        center: [173.5, -41],
+        zoom: 4.6
+      });
+
+      map.addControl(new mapboxgl.NavigationControl(), "top-right");
+
+      map.on("load", () => {
+        const bounds = new mapboxgl.LngLatBounds();
+
+        attractions.forEach((place) => {
+          bounds.extend(place.coords);
+
+          new mapboxgl.Marker({ color: "#000" })
+            .setLngLat(place.coords)
+            .setPopup(
+              new mapboxgl.Popup({ offset: 20 })
+                .setHTML(`<strong>${place.name}</strong>`)
+            )
+            .addTo(map);
+        });
+
+        map.fitBounds(bounds, { padding: 60, maxZoom: 10 });
+      });
+    </script>
 </body>
 
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -760,3 +760,10 @@ iframe {
   background: #084b85;
   border-color: #084b85;
 }
+
+#map {
+  width: 100%;
+  height: 500px;
+  border: 3px solid black;
+  margin: 20px auto;
+}

--- a/scripts/mapbox-config.example.js
+++ b/scripts/mapbox-config.example.js
@@ -1,0 +1,3 @@
+// Copy this file to scripts/mapbox-config.js and replace with your real token.
+// This file is committed; scripts/mapbox-config.js is gitignored.
+window.MAPBOX_ACCESS_TOKEN = "YOURMAPBOXACCESS_TOKEN";


### PR DESCRIPTION
### Motivation
- Replace the embedded iframe map with an interactive Mapbox map to show attraction locations on the page. 
- Keep sensitive API token out of source control by providing an example config and ignoring the real config file.

### Description
- Replaced the iframe in `attractions.html` with a `div` container `#map`, updated headings, and added a Mapbox initialization script that loads markers and popups for the attractions list. 
- Added Mapbox CSS/JS includes and a small runtime check that warns if `window.MAPBOX_ACCESS_TOKEN` is missing and prevents map setup when missing. 
- Added `css` rules for `#map` in `css/style.css` to size and style the map. 
- Added `scripts/mapbox-config.example.js` with `window.MAPBOX_ACCESS_TOKEN = "YOURMAPBOXACCESS_TOKEN"` and added `scripts/mapbox-config.js` to `.gitignore` so the real token file is not committed.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef31feb4dc8333a4d5832524ea51e6)