### PR TITLE
Add 'Things to do' travel themes and featured destinations to attractions page

### DIFF
--- a/attractions.html
+++ b/attractions.html
@@ -64,9 +64,69 @@
  
     <!--MAIN ATTRACTIONS-->
     <div class="container" id="attractions">
-        <h3 class="display-4 lead">Top Things to Do in New Zealand</h3>
-        <p class="sub-heading">Whether you're looking for a family trip or holiday, this is where you'll find the most
-            beautiful and popular activities.</p>
+        <h3 class="display-4 lead">Things to do in New Zealand</h3>
+        <p class="sub-heading">A curated overview of New Zealand attractions, activities, and travel themes across outdoor adventures, culture, relaxation, and featured destinations.</p>
+
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <h4 class="card-title">Travel Themes</h4>
+                        <p class="mb-3">Explore these categories inspired by <a href="https://www.newzealand.com/nz/things-to-do" target="_blank" rel="noopener noreferrer">newzealand.com</a> (last updated: 2025).</p>
+                        <div class="row">
+                            <div class="col-md-6 col-lg-4 mb-3">
+                                <h5>Outdoor Adventures</h5>
+                                <p>Walking, hiking, wildlife encounters, and iconic landscapes across Aotearoa.</p>
+                                <ul>
+                                    <li>Walking and hiking trails nationwide</li>
+                                    <li>Short walks and multi-day treks</li>
+                                    <li>Stewart Island/Rakiura, Fiordland, Tongariro National Park</li>
+                                    <li>Rare birds, dolphins, and whales</li>
+                                </ul>
+                            </div>
+                            <div class="col-md-6 col-lg-4 mb-3">
+                                <h5>Relax</h5>
+                                <p>Laid-back Kiwi lifestyle experiences including beaches, hot pools, and shopping.</p>
+                                <ul>
+                                    <li>Beaches for sunbathing</li>
+                                    <li>Hot pools</li>
+                                    <li>Shopping for quirky souvenirs</li>
+                                </ul>
+                            </div>
+                            <div class="col-md-6 col-lg-4 mb-3">
+                                <h5>Culture</h5>
+                                <p>Kiwi culture, Te Reo Māori, local interactions, and guided tours.</p>
+                                <ul>
+                                    <li>Practise Te Reo Māori</li>
+                                    <li>Chat with local café owners</li>
+                                    <li>Take guided tours</li>
+                                </ul>
+                            </div>
+                            <div class="col-md-6 col-lg-4 mb-3">
+                                <h5>Food &amp; Drink</h5>
+                                <p>Local cuisine, vineyards, and culinary experiences.</p>
+                            </div>
+                            <div class="col-md-6 col-lg-4 mb-3">
+                                <h5>Home of Middle-earth™</h5>
+                                <p>Experiences connected to The Lord of the Rings and The Hobbit films.</p>
+                            </div>
+                            <div class="col-md-6 col-lg-4 mb-3">
+                                <h5>Events</h5>
+                                <p>Events and happenings across New Zealand.</p>
+                            </div>
+                        </div>
+
+                        <h5 class="mt-2">Featured destinations</h5>
+                        <p>Rotorua, Abel Tasman National Park, Lake Tekapo / Takapō, Patea, Doubtful Sound, and Waitomo Caves (featured in Minecraft collaboration).</p>
+
+                        <h5>Holiday types</h5>
+                        <p>Backpacker • Luxury lodges • Multi-day tours • Tour packages</p>
+                        <p class="mb-0"><strong>Follow:</strong> X, Instagram, Facebook, YouTube &nbsp;|&nbsp; <strong>Support:</strong> Help, FAQs, Adding your business, Linking to newzealand.com, Terms of use, Privacy Policy, Cookies</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!--ATTRACTIONS LIST-->
         <div class="row">
             <div class="col">


### PR DESCRIPTION
### Motivation
- Align the Attractions page with the provided "Things to do in New Zealand" dataset by surfacing travel themes, featured destinations, and holiday types as a curated overview. 
- Provide visitors context and quick links to social/support information and the original source so the static page better reflects the dataset and source metadata.

### Description
- Updated the section heading and intro text in `attractions.html` to "Things to do in New Zealand" with a summary that matches the provided dataset. 
- Added a new "Travel Themes" card containing the categories: Outdoor Adventures, Relax, Culture, Food & Drink, Home of Middle-earth™, and Events, including the supplied highlights. 
- Inserted featured destinations and holiday types into the new card and added a compact `Follow` / `Support` reference line. 
- Changes are limited to static HTML content in the single file `attractions.html` and include an external link to the source (`newzealand.com`) and a `last updated: 2025` note.

### Testing
- Ran `git diff --check` to validate there are no index/whitespace errors and it completed successfully.
- Verified the edited `attractions.html` contains the new content block and the original attraction cards remain unchanged via a local diff check which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3e14844c8333b2970c34fad82a2c)