### PR TITLE
Add Things to Do dataset and refresh homepage travel themes

### DIFF
--- a/data/things-to-do.json
+++ b/data/things-to-do.json
@@ -1,0 +1,104 @@
+{
+  "source": "https://www.newzealand.com/nz/things-to-do",
+  "title": "Things to do in New Zealand",
+  "summary": "A curated overview of New Zealand attractions, activities, and travel themes across outdoor adventures, culture, relaxation, and featured destinations.",
+  "categories": [
+    {
+      "id": "outdoor_adventures",
+      "name": "Outdoor Adventures",
+      "description": "Walking, hiking, wildlife encounters, and iconic landscapes across Aotearoa.",
+      "highlights": [
+        "Walking and hiking trails nationwide",
+        "Short walks and multi-day treks",
+        "Destinations: Stewart Island/Rakiura, Fiordland, Tongariro National Park",
+        "Wildlife: rare birds, dolphins, whales"
+      ],
+      "tags": ["hiking", "trekking", "wildlife", "national-parks"]
+    },
+    {
+      "id": "relax",
+      "name": "Relax",
+      "description": "Laid-back Kiwi lifestyle experiences including beaches, hot pools, and shopping.",
+      "highlights": [
+        "Beaches for sunbathing",
+        "Hot pools",
+        "Shopping for quirky souvenirs"
+      ],
+      "tags": ["beaches", "hot-pools", "shopping"]
+    },
+    {
+      "id": "culture",
+      "name": "Culture",
+      "description": "Kiwi culture, Te Reo Māori, local interactions, and guided tours.",
+      "highlights": [
+        "Practise Te Reo Māori",
+        "Chat with local café owners",
+        "Take guided tours"
+      ],
+      "tags": ["maori-culture", "tours", "local-experiences"]
+    },
+    {
+      "id": "food_and_drink",
+      "name": "Food & Drink",
+      "description": "Local cuisine, vineyards, and culinary experiences.",
+      "tags": ["food", "wine", "dining"]
+    },
+    {
+      "id": "middle_earth",
+      "name": "Home of Middle-earth™",
+      "description": "Experiences connected to The Lord of the Rings and The Hobbit films.",
+      "tags": ["middle-earth", "film-locations"]
+    },
+    {
+      "id": "events",
+      "name": "Events",
+      "description": "Events and happenings across New Zealand.",
+      "tags": ["events"]
+    }
+  ],
+  "featured_destinations": [
+    {
+      "name": "Rotorua",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Abel Tasman National Park",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Lake Tekapo / Takapō",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Patea",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Doubtful Sound",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Waitomo Caves",
+      "context": "Featured in Minecraft collaboration"
+    }
+  ],
+  "holiday_types": [
+    "Backpacker",
+    "Luxury lodges",
+    "Multi-day tours",
+    "Tour packages"
+  ],
+  "navigation": {
+    "social": ["X", "Instagram", "Facebook", "YouTube"],
+    "support": [
+      "Help",
+      "FAQs",
+      "Adding your business",
+      "Linking to newzealand.com",
+      "Terms of use",
+      "Privacy Policy",
+      "Cookies"
+    ]
+  },
+  "last_updated": "2025"
+}

--- a/index.html
+++ b/index.html
@@ -109,34 +109,71 @@
     <section class="split-highlight activities-section py-5">
       <div class="container">
         <div class="section-heading">
-          <h3>Find must-do activities</h3>
-          <p>Choose experiences by travel style and interests.</p>
+          <h3>Things to do in New Zealand</h3>
+          <p>A curated snapshot inspired by newzealand.com travel themes.</p>
         </div>
         <div class="row">
           <div class="col-md-6 col-lg-3 mb-3">
             <article class="activity-tile">
-              <h4>Adventure</h4>
-              <p>Bungee, jet boating, alpine hikes, and high-energy experiences.</p>
+              <h4>Outdoor Adventures</h4>
+              <p>Walking, hiking, wildlife encounters, and iconic national park landscapes.</p>
             </article>
           </div>
           <div class="col-md-6 col-lg-3 mb-3">
             <article class="activity-tile">
-              <h4>Māori Culture</h4>
-              <p>Discover stories, heritage sites, performances, and authentic local experiences.</p>
+              <h4>Relax</h4>
+              <p>Unwind in beaches, hot pools, and laid-back local shopping spots.</p>
             </article>
           </div>
           <div class="col-md-6 col-lg-3 mb-3">
             <article class="activity-tile">
-              <h4>Food & Wine</h4>
-              <p>Taste regional produce, wineries, breweries, and coastal dining spots.</p>
+              <h4>Culture</h4>
+              <p>Connect with Kiwi culture through Te Reo Māori, local hosts, and guided tours.</p>
             </article>
           </div>
           <div class="col-md-6 col-lg-3 mb-3">
             <article class="activity-tile">
-              <h4>Nature & Wellness</h4>
-              <p>Hot pools, stargazing, wildlife encounters, and peaceful scenic escapes.</p>
+              <h4>Food & Drink</h4>
+              <p>Taste local cuisine, vineyard experiences, and memorable dining moments.</p>
             </article>
           </div>
+        </div>
+        <div class="row mt-3">
+          <div class="col-md-6 col-lg-4 mb-3">
+            <article class="activity-tile h-100">
+              <h4>Home of Middle-earth™</h4>
+              <p>Visit film locations inspired by <em>The Lord of the Rings</em> and <em>The Hobbit</em>.</p>
+            </article>
+          </div>
+          <div class="col-md-6 col-lg-4 mb-3">
+            <article class="activity-tile h-100">
+              <h4>Events</h4>
+              <p>Find seasonal events and happenings across Aotearoa year-round.</p>
+            </article>
+          </div>
+          <div class="col-md-12 col-lg-4 mb-3">
+            <article class="activity-tile h-100">
+              <h4>Holiday Types</h4>
+              <p>Popular options include backpacking, luxury lodges, multi-day tours, and tour packages.</p>
+            </article>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="featured-grid py-5 bg-light">
+      <div class="container">
+        <div class="section-heading">
+          <h3>Featured destinations</h3>
+          <p>Highlighted places include Rotorua, Abel Tasman, Lake Tekapo / Takapō, Patea, Doubtful Sound, and Waitomo Caves.</p>
+        </div>
+        <div class="row text-center">
+          <div class="col-md-4 mb-3"><div class="p-3 bg-white rounded shadow-sm">Rotorua</div></div>
+          <div class="col-md-4 mb-3"><div class="p-3 bg-white rounded shadow-sm">Abel Tasman National Park</div></div>
+          <div class="col-md-4 mb-3"><div class="p-3 bg-white rounded shadow-sm">Lake Tekapo / Takapō</div></div>
+          <div class="col-md-4 mb-3"><div class="p-3 bg-white rounded shadow-sm">Patea</div></div>
+          <div class="col-md-4 mb-3"><div class="p-3 bg-white rounded shadow-sm">Doubtful Sound</div></div>
+          <div class="col-md-4 mb-3"><div class="p-3 bg-white rounded shadow-sm">Waitomo Caves</div></div>
         </div>
       </div>
     </section>
@@ -185,11 +222,12 @@
           <ul class="list-unstyled footer-links">
             <li><a href="history.html">History & culture</a></li>
             <li><a href="contact.html">Contact us</a></li>
+            <li><a href="https://www.newzealand.com/nz/things-to-do">Source: things to do</a></li>
           </ul>
         </div>
       </div>
     </div>
-    <div class="footer-copyright text-center py-3">Pure New Zealand © 2026</div>
+    <div class="footer-copyright text-center py-3">Pure New Zealand © 2026 · Curated dataset last updated: 2025</div>
   </footer>
 
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"


### PR DESCRIPTION
### Motivation
- Provide a machine-friendly, curated representation of the "Things to do in New Zealand" content so the site can consume and reference structured travel themes.
- Surface the dataset's travel categories on the homepage to keep UI and content aligned with the structured source.
- Give users quick access to featured destinations and clear attribution for the source and last-updated timestamp.

### Description
- Add a new structured data file at `data/things-to-do.json` containing categories, featured destinations, holiday types, navigation metadata, and `last_updated` set to `2025`.
- Update the homepage `index.html` activities section to match the supplied categories (Outdoor Adventures, Relax, Culture, Food & Drink, Home of Middle-earth™, Events, and Holiday Types).
- Add a new "Featured destinations" section to the homepage listing Rotorua, Abel Tasman National Park, Lake Tekapo / Takapō, Patea, Doubtful Sound, and Waitomo Caves.
- Add a footer link to the original source (`https://www.newzealand.com/nz/things-to-do`) and append "Curated dataset last updated: 2025" to the site copyright line.

### Testing
- Validated the new JSON with `python -m json.tool data/things-to-do.json`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3e14844c8333b2970c34fad82a2c)