### PR TITLE
Revamp attractions page to data-driven "Things to do" layout

### DIFF
--- a/attractions.html
+++ b/attractions.html
@@ -2,309 +2,95 @@
 <html lang="en">
 
 <head>
-    <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>AOTEAROA | ATTRACTIONS</title>
-
-    <!-- Bootstrap CSS -->
+    <title>AOTEAROA | THINGS TO DO</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
         integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
         integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-        <link rel="stylesheet" href="css/normalize.css">
-        <link rel="stylesheet" href="css/style.css">
-
-    <!--[if it IE 9]->
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js"></script>
-    <![endif]-->
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/style.css">
 </head>
 
 <body class="home-v2" itemscope itemtype="https://schema.org/WebPage">
-    <!--HEADER AND NAVBAR-->
     <header>
-        <!--NAVBAR-->
-            <nav class="navbar navbar-expand-lg navbar-dark home-navbar fixed-top">
-      <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
-          alt="New Zealand fern logo"></a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
-        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="nav navbar-nav ml-auto">
-          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
-          <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
-          <li class="nav-item active"><a class="nav-link" href="attractions.html">Attractions <span
-                class="sr-only">(current)</span></a></li>
-          <li class="nav-item"><a class="nav-link" href="history.html">History</a></li>
-          <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
-          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
-        </ul>
-      </div>
-    </nav>
-               <!--JUMBOTRON-->
-               <div class="jumbotron jumbotron-image-attractions">
-                <div class="jumbotron-text">
-                    <h1>Beautiful Attractions & Locations</h1>
-                </div>
+        <nav class="navbar navbar-expand-lg navbar-dark home-navbar fixed-top">
+            <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
+                    alt="New Zealand fern logo"></a>
+            <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="nav navbar-nav ml-auto">
+                    <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+                    <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
+                    <li class="nav-item active"><a class="nav-link" href="attractions.html">Attractions <span
+                                class="sr-only">(current)</span></a></li>
+                    <li class="nav-item"><a class="nav-link" href="history.html">History</a></li>
+                    <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
+                    <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+                </ul>
             </div>
-       
+        </nav>
+
+        <div class="jumbotron jumbotron-image-attractions">
+            <div class="jumbotron-text">
+                <h1 id="things-title">Things to do in New Zealand</h1>
+            </div>
+        </div>
     </header>
-       <!--BREADCRUMB-->
-        <div class="container">
-            <p>Browse attractions and map locations</p>
-            <ul class="breadcrumb">
-                <li class="breadcrumb-item active"><a href="#attractions">Main Attractions</a></li>
-                <li class="breadcrumb-item"><a href="#locations">New Zealand Locations</a></li>
-            </ul>
-        </div>
-        <!--BREADCRUMB-->
- 
-    <!--MAIN ATTRACTIONS-->
-    <div class="container" id="attractions">
-        <h3 class="display-4 lead">Top Things to Do in New Zealand</h3>
-        <p class="sub-heading">Whether you're looking for a family trip or holiday, this is where you'll find the most
-            beautiful and popular activities.</p>
-        <!--ATTRACTIONS LIST-->
-        <div class="row">
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-item1.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">Abel Tasman National Park</h2>
-                        <p class="card-text">Located on the northern tip of the country’s South Island, this vast
-                            national park is a hiker’s dream. Closed to vehicles, one must enter by boat, foot or small
-                            plane, but the trip is well worth it. While traversing the mountainous terrain, blue
-                            penguins, wekas, oyster catchers, wood pigeons and other rare birds can all be seen.</p>
-                        <a href="https://www.booking.com/region/nz/abel-tasman-national-park.en.html?aid=339464&label=msn-VXyXmmKTHen3AxRxirJL1g-15766284716:tikwd-16732759795:loc-134:neo:mtb:dec:qs9.%20Abel%20Tasman%20National%20Park&utm_campaign=Region%20-%20New%20Zealand&utm_medium=cpc&utm_source=bing&utm_term=VXyXmmKTHen3AxRxirJL1g&msclkid=2491accc80cb1f828fe7f02111f75a17"
-                            class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-item2.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">Waitomo Caves</h2>
-                        <p class="card-text">With dramatic limestone formations, gigantic stalactites and stalagmites,
-                            and subterranean river, New Zealand's Waitomo Caves hold adventure at every turn. This
-                            network of underground caverns is one of the best places in New Zealand to spot glowworms,
-                            and the glittering creatures provide a magical backdrop to the caves' natural wonders.</p>
-                        <a href="https://www.getyourguide.com/-l35827/?cmp=bing&campaign_id=326339443&adgroup_id=1249045465901718&target_id=kwd-78065498297442:loc-134&match_type=e&ad_id=78065427421626&msclkid=b4d55c3d19d418253a0f00d08db9d99a&loc_physical_ms=2511&feed_item_id=&keyword=waitomo%20caves&partner_id=CD951&utm_source=bing&utm_medium=cpc&utm_campaign=new%20zealand%3A7%7Ccore%7Cen%7Cau&utm_term=waitomo%20caves&utm_content=waitomo%3A32442%7Cf5%7Cwaitomo%20caves%3A35827%7Ccave%20tour%3A1302%7C%7Btd14%7D%7C%7Byr18%7D"
-                            class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-item3.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">Rainbows End</h2>
-                        <p class="card-text">Rainbow's End includes the main theme park and also Kidz Kingdom, a family
-                            entertainment center for children 8 years and under. The park, owned by Rangatira Limited,
-                            is currently New Zealand's largest theme park and currently employs up to 300 staff.</p>
-                        <a href="https://rainbowsend.co.nz/" class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-item4.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">Shotover Canyon Swing</h2>
-                        <p class="card-text">Adrenaline attraction featuring a freefalling swing ride & zip lines over
-                            sheer river canyon walls in the South Island.</p>
-                        <a href="https://www.canyonswing.co.nz/canyon-swing/?gclid=Cj0KCQjwuLPnBRDjARIsACDzGL03uNooQTt_yzW0xCM86UN2pAYowRgxd95sllBFyoem0rMw-qiabLcaAr9HEALw_wcB"
-                            class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-item5.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">Huka Falls</h2>
-                        <p class="card-text">The Huka Falls are a set of waterfalls on the Waikato River that drains
-                            Lake Taupo in New Zealand. A few hundred metres upstream from the Huka Falls, the Waikato
-                            River narrows from approximately 100 metres across into a canyon only 15 metres across.</p>
-                        <a href="http://hukafalls.com/" class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-items6.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">Air Force Museum of New Zealand</h2>
-                        <p class="card-text">The Air Force Museum of New Zealand is the national museum for the Royal
-                            New Zealand Air Force (RNZAF) and one of New Zealand’s premier attractions. Located in
-                            Christchurch on the site of the former Air Force Base at Wigram, the Museum offers a unique
-                            and memorable visitor experience. With over 30 historic aircraft, hands-on exhibitions and
-                            programmes, guided tours and even a flight simulator, all with FREE entry, it is the ideal
-                            place to bring the whole family for a great day out. </p>
-                        <a href="https://www.airforcemuseum.co.nz/" class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-item7.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">Museum of New Zealand Te Papa Tongarewa</h2>
-                        <p class="card-text">The Museum of New Zealand Te Papa Tongarewa is New Zealand's national
-                            museum, located in Wellington. Known as Te Papa, or 'Our Place', it opened in 1998 after the
-                            merging of the National Museum and the National Art Gallery. More than 1.5 million people
-                            visit every year. Te Papa Tongarewa translates literally to 'Container of Treasures'. A
-                            fuller interpretation is ‘our container of treasured things and people that spring from
-                            mother earth here in New Zealand’.</p>
-                        <a href="https://www.tepapa.govt.nz/" class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-item8.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">Marokopa Falls Walk</h2>
-                        <p class="card-text">The 35 m high falls are often described as the most beautiful in the
-                            country. Here the Marokopa River cascades over the undercut greywacke basement rock.
-                            Marokopa Falls is 15 km east of Marokopa and 31 km west of Waitomo, on Te Anga Road.</p>
-                        <a href="https://www.tepapa.govt.nz/" class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-item9.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">Splash Planet</h2>
-                        <p class="card-text">Splash Planet is an amusement park and water park one of New Zealands
-                            popular attractions, located in the city of Hastings, New Zealand. The park was opened in
-                            its current form in 1998.</p>
-                        <a href="https://www.splashplanet.co.nz/" class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-            <div class="col">
-                <div class="card">
-                    <img class="card-img-top" src="./images/attractions-item10.jpg" alt="NZ-Attractions Photo">
-                    <div class="card-body">
-                        <h2 class="card-title">SEA LIFE Kelly Tarlton's Aquarium</h2>
-                        <p class="card-text">Kelly Tarlton's Sea Life Aquarium is a public aquarium in Auckland, New
-                            Zealand that was opened in 1985. Located at 23 Tamaki Drive, it was the brainchild of New
-                            Zealand marine archaeologist and diver Kelly Tarlton.</p>
-                        <a href="https://www.kellytarltons.co.nz/" class="btn btn-dark">See More</a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <!--MAIN ATTRACTIONS-->
 
-    <!--LOCATIONS MAP-->
-    <div class="container" id="locations">
-        <h3 class="display-4 lead text-center">New Zealand Locations</h3>
-        <p class="sub-heading">Explore attractions across Aotearoa</p>
+    <main class="container">
+        <section class="my-4">
+            <p id="things-summary" class="lead">Loading curated activities and destinations...</p>
+            <p id="things-meta" class="text-muted"></p>
+        </section>
 
-        <div id="map"></div>
-    </div>
+        <section class="my-4" id="attractions">
+            <h2 class="mb-3">Travel Themes</h2>
+            <div id="categories-grid" class="row"></div>
+        </section>
 
-    <div class="container">
-        <p>Browse attractions and map locations</p>
-        <ul class="breadcrumb">
-            <li class="breadcrumb-item active"><a href="#attractions">Main Attractions</a></li>
-            <li class="breadcrumb-item"><a href="#locations">New Zealand Locations</a></li>
-        </ul>
-    </div>
+        <section class="my-4" id="featured">
+            <h2 class="mb-3">Featured Destinations</h2>
+            <ul id="featured-destinations" class="list-group"></ul>
+        </section>
 
-    <!-- Footer -->
+        <section class="my-4" id="holiday-types-section">
+            <h2 class="mb-3">Holiday Types</h2>
+            <div id="holiday-types"></div>
+        </section>
+
+        <section class="my-4">
+            <div class="row">
+                <div class="col-md-4 mb-3">
+                    <h3>Social</h3>
+                    <ul id="social-links" class="list-group"></ul>
+                </div>
+                <div class="col-md-8 mb-3">
+                    <h3>Support</h3>
+                    <ul id="support-links" class="list-group"></ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
     <footer class="page-footer home-footer">
-        <!-- Copyright -->
-        <div class="footer-copyright text-center py-3">Pure New Zealand © 2026
-        </div>
-        <!-- Copyright -->
+        <div class="footer-copyright text-center py-3">Pure New Zealand © 2026</div>
     </footer>
 
-    <!-- jQuery first, then Tether, then Bootstrap JS. -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
         integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous">
-    </script>
+        </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
         integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous">
-    </script>
+        </script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
         integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous">
-    </script>
-    <script src="scripts/main.js"></script>
-    <link
-        href="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.css"
-        rel="stylesheet"
-    />
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.15.0/mapbox-gl.js"></script>
-
-    <script>
-      (function loadAttractionsMap() {
-        const mapboxToken =
-          (window.__ENV__ && window.__ENV__.MAPBOX_ACCESS_TOKEN) ||
-          (typeof process !== "undefined" && process.env && process.env.MAPBOX_ACCESS_TOKEN) ||
-          window.MAPBOX_ACCESS_TOKEN;
-        const mapElement = document.getElementById("map");
-
-        if (!mapElement) {
-          return;
-        }
-
-        if (!mapboxToken) {
-          console.error("Mapbox token missing. Add scripts/mapbox-config.js from scripts/mapbox-config.example.js.");
-          mapElement.innerHTML = "<p class='text-center p-4 mb-0'>Map unavailable: add a Mapbox token in <code>scripts/mapbox-config.js</code>.</p>";
-          return;
-        }
-
-        mapboxgl.accessToken = mapboxToken;
-
-        const attractions = [
-          { name: "Abel Tasman National Park", coords: [172.9, -40.8333] },
-          { name: "Waitomo Glowworm Caves", coords: [175.1036, -38.2608] },
-          { name: "Rainbow's End", coords: [174.8840, -36.9940] },
-          { name: "Shotover Canyon Swing", coords: [168.6611, -45.0306] },
-          { name: "Huka Falls", coords: [176.0897, -38.6495] },
-          { name: "Air Force Museum of New Zealand", coords: [172.5477, -43.5466] },
-          { name: "Te Papa Tongarewa", coords: [174.7821, -41.2905] },
-          { name: "Marokopa Falls", coords: [174.8518, -38.2615] },
-          { name: "Splash Planet", coords: [176.8636, -39.6440] },
-          { name: "SEA LIFE Kelly Tarlton's Aquarium", coords: [174.8172, -36.8458] }
-        ];
-
-        const map = new mapboxgl.Map({
-          container: "map",
-          style: "mapbox://styles/mapbox/outdoors-v12",
-          center: [173.5, -41],
-          zoom: 4.6
-        });
-
-        map.addControl(new mapboxgl.NavigationControl(), "top-right");
-
-        map.on("load", () => {
-          const bounds = new mapboxgl.LngLatBounds();
-
-          attractions.forEach((place) => {
-            bounds.extend(place.coords);
-
-            new mapboxgl.Marker({ color: "#000" })
-              .setLngLat(place.coords)
-              .setPopup(
-                new mapboxgl.Popup({ offset: 20 })
-                  .setHTML(`<strong>${place.name}</strong>`)
-              )
-              .addTo(map);
-          });
-
-          map.fitBounds(bounds, { padding: 60, maxZoom: 10 });
-        });
-      })();
-    </script>
+        </script>
+    <script src="scripts/things-to-do.js"></script>
 </body>
 
 </html>

--- a/data/things-to-do.json
+++ b/data/things-to-do.json
@@ -1,0 +1,104 @@
+{
+  "source": "https://www.newzealand.com/nz/things-to-do",
+  "title": "Things to do in New Zealand",
+  "summary": "A curated overview of New Zealand attractions, activities, and travel themes across outdoor adventures, culture, relaxation, and featured destinations.",
+  "categories": [
+    {
+      "id": "outdoor_adventures",
+      "name": "Outdoor Adventures",
+      "description": "Walking, hiking, wildlife encounters, and iconic landscapes across Aotearoa.",
+      "highlights": [
+        "Walking and hiking trails nationwide",
+        "Short walks and multi-day treks",
+        "Destinations: Stewart Island/Rakiura, Fiordland, Tongariro National Park",
+        "Wildlife: rare birds, dolphins, whales"
+      ],
+      "tags": ["hiking", "trekking", "wildlife", "national-parks"]
+    },
+    {
+      "id": "relax",
+      "name": "Relax",
+      "description": "Laid-back Kiwi lifestyle experiences including beaches, hot pools, and shopping.",
+      "highlights": [
+        "Beaches for sunbathing",
+        "Hot pools",
+        "Shopping for quirky souvenirs"
+      ],
+      "tags": ["beaches", "hot-pools", "shopping"]
+    },
+    {
+      "id": "culture",
+      "name": "Culture",
+      "description": "Kiwi culture, Te Reo Māori, local interactions, and guided tours.",
+      "highlights": [
+        "Practise Te Reo Māori",
+        "Chat with local café owners",
+        "Take guided tours"
+      ],
+      "tags": ["maori-culture", "tours", "local-experiences"]
+    },
+    {
+      "id": "food_and_drink",
+      "name": "Food & Drink",
+      "description": "Local cuisine, vineyards, and culinary experiences.",
+      "tags": ["food", "wine", "dining"]
+    },
+    {
+      "id": "middle_earth",
+      "name": "Home of Middle-earth™",
+      "description": "Experiences connected to The Lord of the Rings and The Hobbit films.",
+      "tags": ["middle-earth", "film-locations"]
+    },
+    {
+      "id": "events",
+      "name": "Events",
+      "description": "Events and happenings across New Zealand.",
+      "tags": ["events"]
+    }
+  ],
+  "featured_destinations": [
+    {
+      "name": "Rotorua",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Abel Tasman National Park",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Lake Tekapo / Takapō",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Patea",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Doubtful Sound",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Waitomo Caves",
+      "context": "Featured in Minecraft collaboration"
+    }
+  ],
+  "holiday_types": [
+    "Backpacker",
+    "Luxury lodges",
+    "Multi-day tours",
+    "Tour packages"
+  ],
+  "navigation": {
+    "social": ["X", "Instagram", "Facebook", "YouTube"],
+    "support": [
+      "Help",
+      "FAQs",
+      "Adding your business",
+      "Linking to newzealand.com",
+      "Terms of use",
+      "Privacy Policy",
+      "Cookies"
+    ]
+  },
+  "last_updated": "2025"
+}

--- a/scripts/things-to-do.js
+++ b/scripts/things-to-do.js
@@ -1,0 +1,68 @@
+(function () {
+  function tagBadge(tag) {
+    return '<span class="badge badge-secondary mr-1 mb-1">' + tag + '</span>';
+  }
+
+  function categoryCard(category) {
+    var highlights = (category.highlights || []).map(function (item) {
+      return '<li>' + item + '</li>';
+    }).join('');
+
+    var tags = (category.tags || []).map(tagBadge).join('');
+
+    return [
+      '<div class="col-lg-4 col-md-6 mb-4">',
+      '  <div class="card h-100">',
+      '    <div class="card-body">',
+      '      <h4 class="card-title">' + category.name + '</h4>',
+      '      <p class="card-text">' + category.description + '</p>',
+      highlights ? '      <ul>' + highlights + '</ul>' : '',
+      '      <div>' + tags + '</div>',
+      '    </div>',
+      '  </div>',
+      '</div>'
+    ].join('');
+  }
+
+  function simpleList(items) {
+    return items.map(function (item) {
+      return '<li class="list-group-item">' + item + '</li>';
+    }).join('');
+  }
+
+  function init(data) {
+    var titleEl = document.getElementById('things-title');
+    var summaryEl = document.getElementById('things-summary');
+    var metaEl = document.getElementById('things-meta');
+    var categoriesEl = document.getElementById('categories-grid');
+    var destinationsEl = document.getElementById('featured-destinations');
+    var holidaysEl = document.getElementById('holiday-types');
+    var socialEl = document.getElementById('social-links');
+    var supportEl = document.getElementById('support-links');
+
+    titleEl.textContent = data.title;
+    summaryEl.textContent = data.summary;
+    metaEl.innerHTML = 'Source: <a href="' + data.source + '" target="_blank" rel="noopener noreferrer">newzealand.com</a> · Last updated: ' + data.last_updated;
+
+    categoriesEl.innerHTML = data.categories.map(categoryCard).join('');
+
+    destinationsEl.innerHTML = data.featured_destinations.map(function (destination) {
+      return '<li class="list-group-item d-flex justify-content-between align-items-center"><span>' + destination.name + '</span><small class="text-muted">' + destination.context + '</small></li>';
+    }).join('');
+
+    holidaysEl.innerHTML = (data.holiday_types || []).map(function (type) {
+      return '<span class="badge badge-dark mr-2 mb-2 p-2">' + type + '</span>';
+    }).join('');
+
+    socialEl.innerHTML = simpleList(data.navigation.social);
+    supportEl.innerHTML = simpleList(data.navigation.support);
+  }
+
+  fetch('data/things-to-do.json')
+    .then(function (response) { return response.json(); })
+    .then(init)
+    .catch(function () {
+      var summaryEl = document.getElementById('things-summary');
+      summaryEl.textContent = 'Unable to load the things-to-do guide right now. Please try again later.';
+    });
+})();


### PR DESCRIPTION
### Motivation
- Replace the long, static list of attraction cards with a maintainable, data-driven page for the "Things to do in New Zealand" guide.
- Centralise content so the page can be updated from a single JSON source and rendered client-side.
- Simplify the page structure and remove legacy static sections (map and hard-coded cards) in favour of modular sections (themes, featured destinations, holiday types, navigation).

### Description
- Reworked `attractions.html` into a streamlined, data-driven layout that loads content at runtime and exposes sections for travel themes, featured destinations, holiday types, and social/support links.
- Added `data/things-to-do.json` as the structured content source containing the provided metadata, categories, destinations, holiday types, navigation, and last-updated year.
- Added `scripts/things-to-do.js` which fetches the JSON and renders category cards, badges, lists, and a fallback message when loading fails.
- Removed the previous hard-coded attractions cards and the Mapbox map initialization to simplify the page and centralise content in the JSON file.

### Testing
- Ran `python -m json.tool data/things-to-do.json` to validate JSON syntax and it completed successfully.
- Ran `node --check scripts/things-to-do.js` to verify the client-side script parses without syntax errors and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3e14844c8333b2970c34fad82a2c)