### PR TITLE
Add "Things to do" page with data and styles, update home nav

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -767,3 +767,41 @@ iframe {
   border: 3px solid black;
   margin: 20px auto;
 }
+
+/* THINGS TO DO PAGE */
+.things-hero {
+  min-height: 55vh;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0.45)), url("../images/home-cover.jpg");
+  background-size: cover;
+  background-position: center;
+}
+
+.destination-chip {
+  background: #f4f7fb;
+  border: 1px solid #d7e0ea;
+  border-radius: 10px;
+  padding: 16px;
+  text-align: center;
+  font-weight: 600;
+  min-height: 100%;
+}
+
+.holiday-types {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+  list-style: none;
+  padding-left: 0;
+}
+
+.holiday-types li {
+  background: #f8f8f8;
+  border-left: 4px solid #205493;
+  padding: 10px 12px;
+}
+
+.last-updated {
+  margin-top: 20px;
+  font-size: 14px;
+  color: #4d4d4d;
+}

--- a/data/things-to-do.json
+++ b/data/things-to-do.json
@@ -1,0 +1,104 @@
+{
+  "source": "https://www.newzealand.com/nz/things-to-do",
+  "title": "Things to do in New Zealand",
+  "summary": "A curated overview of New Zealand attractions, activities, and travel themes across outdoor adventures, culture, relaxation, and featured destinations.",
+  "categories": [
+    {
+      "id": "outdoor_adventures",
+      "name": "Outdoor Adventures",
+      "description": "Walking, hiking, wildlife encounters, and iconic landscapes across Aotearoa.",
+      "highlights": [
+        "Walking and hiking trails nationwide",
+        "Short walks and multi-day treks",
+        "Destinations: Stewart Island/Rakiura, Fiordland, Tongariro National Park",
+        "Wildlife: rare birds, dolphins, whales"
+      ],
+      "tags": ["hiking", "trekking", "wildlife", "national-parks"]
+    },
+    {
+      "id": "relax",
+      "name": "Relax",
+      "description": "Laid-back Kiwi lifestyle experiences including beaches, hot pools, and shopping.",
+      "highlights": [
+        "Beaches for sunbathing",
+        "Hot pools",
+        "Shopping for quirky souvenirs"
+      ],
+      "tags": ["beaches", "hot-pools", "shopping"]
+    },
+    {
+      "id": "culture",
+      "name": "Culture",
+      "description": "Kiwi culture, Te Reo Māori, local interactions, and guided tours.",
+      "highlights": [
+        "Practise Te Reo Māori",
+        "Chat with local café owners",
+        "Take guided tours"
+      ],
+      "tags": ["maori-culture", "tours", "local-experiences"]
+    },
+    {
+      "id": "food_and_drink",
+      "name": "Food & Drink",
+      "description": "Local cuisine, vineyards, and culinary experiences.",
+      "tags": ["food", "wine", "dining"]
+    },
+    {
+      "id": "middle_earth",
+      "name": "Home of Middle‑earth™",
+      "description": "Experiences connected to The Lord of the Rings and The Hobbit films.",
+      "tags": ["middle-earth", "film-locations"]
+    },
+    {
+      "id": "events",
+      "name": "Events",
+      "description": "Events and happenings across New Zealand.",
+      "tags": ["events"]
+    }
+  ],
+  "featured_destinations": [
+    {
+      "name": "Rotorua",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Abel Tasman National Park",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Lake Tekapo / Takapō",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Patea",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Doubtful Sound",
+      "context": "Featured in Minecraft collaboration"
+    },
+    {
+      "name": "Waitomo Caves",
+      "context": "Featured in Minecraft collaboration"
+    }
+  ],
+  "holiday_types": [
+    "Backpacker",
+    "Luxury lodges",
+    "Multi-day tours",
+    "Tour packages"
+  ],
+  "navigation": {
+    "social": ["X", "Instagram", "Facebook", "YouTube"],
+    "support": [
+      "Help",
+      "FAQs",
+      "Adding your business",
+      "Linking to newzealand.com",
+      "Terms of use",
+      "Privacy Policy",
+      "Cookies"
+    ]
+  },
+  "last_updated": "2025"
+}

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
       <div class="collapse navbar-collapse" id="navbarNav">
         <ul class="nav navbar-nav ml-auto">
           <li class="nav-item active"><a class="nav-link" href="index.html">Home <span class="sr-only">(current)</span></a></li>
+          <li class="nav-item"><a class="nav-link" href="things-to-do.html">Things to do</a></li>
           <li class="nav-item"><a class="nav-link" href="beaches-coast.html">Beaches & Coast</a></li>
           <li class="nav-item"><a class="nav-link" href="attractions.html">Attractions</a></li>
           <li class="nav-item"><a class="nav-link" href="history.html">History</a></li>
@@ -42,7 +43,7 @@
         <h1>Welcome to Aotearoa</h1>
         <p class="hero-subtitle">Plan unforgettable adventures across mountains, coastlines, and vibrant cities.</p>
         <div class="hero-actions">
-          <a class="btn btn-light btn-lg" href="attractions.html">Explore destinations</a>
+          <a class="btn btn-light btn-lg" href="things-to-do.html">Explore things to do</a>
           <a class="btn btn-outline-light btn-lg" href="events.html">See events</a>
         </div>
       </div>

--- a/things-to-do.html
+++ b/things-to-do.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>AOTEAROA | THINGS TO DO</title>
+
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+    integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+  <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
+    integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+  <link rel="stylesheet" href="css/normalize.css">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+
+<body class="home-v2" itemscope itemtype="https://schema.org/WebPage">
+  <header class="home-header">
+    <nav class="navbar navbar-expand-lg navbar-dark home-navbar fixed-top">
+      <a class="navbar-brand" href="index.html"><img src="images/1280px-NZ_fern_flag.png" width="100" height="45"
+          alt="New Zealand fern logo"></a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
+        aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="nav navbar-nav ml-auto">
+          <li class="nav-item"><a class="nav-link" href="index.html">Home</a></li>
+          <li class="nav-item active"><a class="nav-link" href="things-to-do.html">Things to do <span class="sr-only">(current)</span></a></li>
+          <li class="nav-item"><a class="nav-link" href="attractions.html">Attractions</a></li>
+          <li class="nav-item"><a class="nav-link" href="events.html">Events</a></li>
+          <li class="nav-item"><a class="nav-link" href="contact.html">Contact</a></li>
+        </ul>
+      </div>
+    </nav>
+
+    <section class="hero-banner things-hero">
+      <div class="hero-overlay"></div>
+      <div class="container hero-content">
+        <p class="hero-kicker">Curated travel inspiration</p>
+        <h1>Things to do in New Zealand</h1>
+        <p class="hero-subtitle">Outdoor adventures, culture, relaxation, and iconic destinations across Aotearoa.</p>
+      </div>
+    </section>
+  </header>
+
+  <main>
+    <section class="py-5">
+      <div class="container">
+        <div class="section-heading">
+          <h3>Explore by category</h3>
+          <p>A quick overview inspired by the official New Zealand travel themes.</p>
+        </div>
+        <div class="row">
+          <div class="col-md-6 col-lg-4 mb-4 d-flex">
+            <article class="activity-tile w-100">
+              <h4>Outdoor Adventures</h4>
+              <p>Walking and hiking trails, multi-day treks, and wildlife experiences.</p>
+              <ul>
+                <li>Stewart Island / Rakiura</li>
+                <li>Fiordland</li>
+                <li>Tongariro National Park</li>
+              </ul>
+            </article>
+          </div>
+          <div class="col-md-6 col-lg-4 mb-4 d-flex">
+            <article class="activity-tile w-100">
+              <h4>Relax</h4>
+              <p>Slow down with beach days, hot pools, and laid-back shopping.</p>
+              <ul>
+                <li>Sunbathing beaches</li>
+                <li>Hot pools and wellness</li>
+                <li>Quirky souvenirs</li>
+              </ul>
+            </article>
+          </div>
+          <div class="col-md-6 col-lg-4 mb-4 d-flex">
+            <article class="activity-tile w-100">
+              <h4>Culture</h4>
+              <p>Connect with local people, stories, and Te Reo Māori.</p>
+              <ul>
+                <li>Practise Te Reo Māori</li>
+                <li>Meet local makers</li>
+                <li>Take guided tours</li>
+              </ul>
+            </article>
+          </div>
+          <div class="col-md-6 col-lg-4 mb-4 d-flex">
+            <article class="activity-tile w-100">
+              <h4>Food &amp; Drink</h4>
+              <p>Sample local cuisine, vineyards, and memorable dining experiences.</p>
+            </article>
+          </div>
+          <div class="col-md-6 col-lg-4 mb-4 d-flex">
+            <article class="activity-tile w-100">
+              <h4>Home of Middle-earth™</h4>
+              <p>Find experiences connected to The Lord of the Rings and The Hobbit films.</p>
+            </article>
+          </div>
+          <div class="col-md-6 col-lg-4 mb-4 d-flex">
+            <article class="activity-tile w-100">
+              <h4>Events</h4>
+              <p>Discover happenings and seasonal events across New Zealand.</p>
+            </article>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="featured-grid py-5">
+      <div class="container">
+        <div class="section-heading">
+          <h3>Featured destinations</h3>
+          <p>Highlighted destinations from the Minecraft collaboration showcase.</p>
+        </div>
+        <div class="row">
+          <div class="col-sm-6 col-lg-4 mb-3"><div class="destination-chip">Rotorua</div></div>
+          <div class="col-sm-6 col-lg-4 mb-3"><div class="destination-chip">Abel Tasman National Park</div></div>
+          <div class="col-sm-6 col-lg-4 mb-3"><div class="destination-chip">Lake Tekapo / Takapō</div></div>
+          <div class="col-sm-6 col-lg-4 mb-3"><div class="destination-chip">Patea</div></div>
+          <div class="col-sm-6 col-lg-4 mb-3"><div class="destination-chip">Doubtful Sound</div></div>
+          <div class="col-sm-6 col-lg-4 mb-3"><div class="destination-chip">Waitomo Caves</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="py-5">
+      <div class="container">
+        <div class="section-heading">
+          <h3>Holiday types</h3>
+        </div>
+        <ul class="holiday-types">
+          <li>Backpacker</li>
+          <li>Luxury lodges</li>
+          <li>Multi-day tours</li>
+          <li>Tour packages</li>
+        </ul>
+        <p class="last-updated">Source: newzealand.com • Last updated: 2025</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="page-footer home-footer">
+    <div class="container py-4">
+      <div class="row">
+        <div class="col-md-6 mb-3 mb-md-0">
+          <h6>Social</h6>
+          <p>X, Instagram, Facebook, YouTube</p>
+        </div>
+        <div class="col-md-6">
+          <h6>Support</h6>
+          <p>Help • FAQs • Adding your business • Terms • Privacy • Cookies</p>
+        </div>
+      </div>
+    </div>
+    <div class="footer-copyright text-center py-3">Pure New Zealand © 2026</div>
+  </footer>
+
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+    integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js"
+    integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
+    integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+</body>
+
+</html>


### PR DESCRIPTION
### Motivation
- Provide a curated “Things to do in New Zealand” content page surfaced from the supplied structured payload.  
- Preserve the original structured source as a reusable data artifact in the repository.  
- Make the new page discoverable from the home page via navigation and hero CTA.

### Description
- Added a new page `things-to-do.html` that renders categories, featured destinations, holiday types, and support/social info.  
- Added the source payload as `data/things-to-do.json` to store the original structured content for reuse.  
- Appended styles for the new page to `css/style.css` (`.things-hero`, `.destination-chip`, `.holiday-types`, `.last-updated`).  
- Updated `index.html` to include a `Things to do` nav item and changed the hero CTA to link to `things-to-do.html`.

### Testing
- Validated JSON syntax with `python -m json.tool data/things-to-do.json` which succeeded.  
- Ran `git diff --check` to detect whitespace/diff issues which returned clean.  
- Changes were committed locally (commit created during the update process).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3e14844c8333b2970c34fad82a2c)